### PR TITLE
⚡ Bolt: Replace cursor polling with event listener

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-26 - Stop Polling!
+**Learning:** Polling to update UI like cursor position using `setInterval` wastes CPU cycles when the application is idle, which violates the core performance budget of CPU Idle < 1%.
+**Action:** Instead of `setInterval`, we should listen to the actual events that indicate a change, like selection changes in CodeMirror, and update the UI accordingly.

--- a/src/editor.js
+++ b/src/editor.js
@@ -28,9 +28,10 @@ let isProgrammaticSetting = false;
  * Initialize the CodeMirror 6 editor
  * @param {HTMLElement} domEl - Container element
  * @param {Function} onChange - Callback fired with doc string after 150ms debounce
+ * @param {Function} onSelectionChange - Callback fired on selection change
  * @returns {Object} Editor API
  */
-export function initEditor(domEl, onChange) {
+export function initEditor(domEl, onChange, onSelectionChange) {
   onChangeCallback = onChange;
 
   const updateListener = EditorView.updateListener.of((update) => {
@@ -42,6 +43,13 @@ export function initEditor(domEl, onChange) {
           onChangeCallback(update.state.doc.toString(), isProgrammatic);
         }
       }, 150);
+    }
+
+    // Bolt Optimization: Call onSelectionChange to avoid UI polling
+    if (update.selectionSet || update.docChanged) {
+      if (onSelectionChange) {
+        onSelectionChange();
+      }
     }
   });
 

--- a/src/main.js
+++ b/src/main.js
@@ -48,7 +48,7 @@ const isTauri = typeof window !== 'undefined' && !!(window.__TAURI__ || window._
 // ---- Initialize ----
 window.addEventListener('DOMContentLoaded', async () => {
   // Initialize editor
-  editorAPI = initEditor(document.getElementById('editor-pane'), onContentChange);
+  editorAPI = initEditor(document.getElementById('editor-pane'), onContentChange, updateCursorPosition);
 
   // Initialize preview
   previewAPI = initPreview(document.getElementById('preview-content'));
@@ -521,11 +521,6 @@ function initKeyboardShortcuts() {
       toggleShortcutsModal();
     }
   });
-
-  // Update cursor position on editor selection change
-  setInterval(() => {
-    updateCursorPosition();
-  }, 250);
 }
 
 // ---- Unsaved Changes Dialog ----


### PR DESCRIPTION
💡 **What:** 
Removed the `setInterval` that was polling for cursor position updates every 250ms. Modified `initEditor` to accept an `onSelectionChange` callback, which is now triggered inside CodeMirror's `updateListener` whenever the selection or document changes. Passed `updateCursorPosition` as this callback in `src/main.js`.

🎯 **Why:** 
Polling the UI for updates when the application is idle wastes CPU cycles and battery life, which violates the core performance budget of CPU Idle < 1%. Using an event-driven architecture ensures the UI is only updated when the state actually changes.

📊 **Impact:** 
Eliminates unnecessary CPU usage when the editor is idle. Improves application responsiveness, as the cursor position is now updated synchronously upon selection change instead of waiting for the next 250ms tick.

🔬 **Measurement:** 
Verify the improvement by profiling CPU usage when the application is left idle (it should be virtually 0%). Check that the cursor position in the status bar updates correctly and instantaneously when clicking or typing in the editor. Run `npm run test` to ensure no functionality is broken.

---
*PR created automatically by Jules for task [17798518817270745795](https://jules.google.com/task/17798518817270745795) started by @prathamreet*