### PR TITLE
🎨 Palette: Add keyboard focus indicators for improved accessibility

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -96,6 +96,11 @@ html, body {
   color: var(--text);
 }
 
+.title-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
 .title-btn-close:hover {
   background: #e81123;
   color: #fff;
@@ -131,6 +136,11 @@ html, body {
 .toolbar-btn:hover {
   background: var(--border);
   color: var(--text);
+}
+
+.toolbar-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 40%, transparent);
 }
 
 .toolbar-btn.active {
@@ -201,6 +211,11 @@ html, body {
 
 .dropdown-item:hover {
   background: var(--border);
+}
+
+.dropdown-item:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--accent) 40%, transparent);
 }
 
 .dropdown-item.active {
@@ -353,6 +368,11 @@ html, body {
   color: var(--text);
 }
 
+.settings-close:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
 .settings-body {
   padding: 16px 20px;
   display: flex;
@@ -420,6 +440,10 @@ html, body {
   opacity: 0;
   width: 0;
   height: 0;
+}
+
+.toggle-switch input:focus-visible + .toggle-slider {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 40%, transparent);
 }
 
 .toggle-slider {


### PR DESCRIPTION
💡 **What:** Added explicit `:focus-visible` states to custom interactive UI elements including `.title-btn`, `.toolbar-btn`, `.dropdown-item`, `.settings-close`, and `.toggle-switch input`.
🎯 **Why:** To improve keyboard navigation. Custom UI elements previously lacked visual focus indicators, making it difficult for keyboard users to track their position.
♿ **Accessibility:** Significantly improves WCAG 2.1 Success Criterion 2.4.7 (Focus Visible) compliance by providing clear, themed visual feedback during keyboard navigation.
📸 **Before/After:** Keyboard focus is now clearly visible with an accent-colored outline on custom UI elements.

---
*PR created automatically by Jules for task [7314010595888541412](https://jules.google.com/task/7314010595888541412) started by @prathamreet*