### PR TITLE
feat(ui): fullscreen preview mode and keyboard-first shortcut overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You probably already have a Markdown workflow, and it probably costs you 300 MB 
 Feather MD is the small, fast thing that lives between those edges.
 
 * **Double-click a `.md` file and it opens.** Real OS file association. No "open in VS Code" workaround.
-* **Side-by-side preview with bidirectional scroll sync, out of the box.** Toggle it off with `Alt + S` if you want.
+* **Side-by-side preview with bidirectional scroll sync, out of the box.** Toggle it off with `Alt + X` if you want.
 * **A dedicated window, not another browser tab.** No distraction, no lost cursor.
 * **~5 MB Windows installer, around 50 MB resident.** Editing text should not cost a gigabyte of memory.
 * **Tauri, not Electron.** Uses your OS WebView, ships no browser runtime, signs every update with Ed25519.
@@ -97,7 +97,7 @@ Release bundles land in:
 | **Unified Header** | A single 40 px bar combines title, menus, font-size slider, and corner-flush Win11-style window controls. Active document title is absolutely centered with transparent pointer events. |
 | **Hover Dropdown Menus** | File / View / Style open on hover with a 180 ms grace timeout and diagonal pointer bridge to prevent accidental dismissals. Theme, Font, and Tab pickers stay open so you can preview multiple options without re-opening. |
 | **Native dual-pane** | Editor on the left, live preview on the right. Resizable from 20% to 80%. Double-click the divider to reset to center. |
-| **Bidirectional scroll sync** | Scroll either pane, the other follows. Ratio-based, no jitter on long documents. Toggle with `Alt + S`. |
+| **Bidirectional scroll sync** | Scroll either pane, the other follows. Ratio-based, no jitter on long documents. Toggle with `Alt + X`. |
 | **CodeMirror 6 editor** | Markdown syntax styling, code folding, bracket and quote auto-pair, active-line highlight, find and replace. |
 | **Highlight.js code blocks** | On-demand language loading for fenced blocks. Hundreds of languages, no startup penalty. |
 | **10 built-in themes** | Five light, five dark. Switches in under 1 ms via a single `data-theme` attribute. All consolidated into one stylesheet, zero JS overhead. |
@@ -160,13 +160,23 @@ If you are managing thousands of linked notes with backlinks and graphs, you wan
 | `Ctrl + O` | Open file |
 | `Ctrl + S` | Save |
 | `Ctrl + Shift + S` | Save as |
+| `Ctrl + R` | Recent files |
 | `Ctrl + P` | Print document |
 | `Ctrl + F` | Find |
 | `Ctrl + H` | Find and replace |
-| `Ctrl + L` | Toggle line numbers |
 | `Alt + Z` | Toggle word wrap |
-| `Alt + S` | Toggle scroll sync |
+| `Alt + X` | Toggle scroll sync |
+| `Alt + C` | Toggle line numbers |
+| `Alt + P` | Toggle page breaks |
+| `Alt + T` then `↑` / `↓` | Cycle theme forward / back |
+| `Alt + F` then `↑` / `↓` | Cycle font forward / back |
+| `Alt + D` then `↑` / `↓` | Cycle tab size forward / back |
+| `F11` | Fullscreen preview (`Esc` exits) |
+| `Ctrl + Q` | Quit |
+| `Ctrl + Shift + R` | Reload |
 | `Ctrl + ?` | Show all shortcuts |
+
+The theme/font/tab-size chords are a leader sequence: tap `Alt + T` (or `F` / `D`), then `↑` / `↓` to cycle within a short window.
 
 Inside the unsaved-changes dialog: `S` save, `N` discard, `C` / `Esc` cancel.
 

--- a/index.html
+++ b/index.html
@@ -47,17 +47,10 @@
             <span class="menu-item-shortcut">Ctrl+Shift+S</span>
           </button>
           <div class="menu-separator"></div>
-          <div class="menu-submenu">
-            <button class="menu-item has-submenu" data-action="recent-files">
-              <span class="menu-item-label">Recent Files</span>
-              <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5">
-                <polyline points="3,2 7,5 3,8" />
-              </svg>
-            </button>
-            <div class="submenu-panel" id="recent-files-submenu">
-              <div class="menu-item-empty">No recent files</div>
-            </div>
-          </div>
+          <button class="menu-item" data-action="recent-files">
+            <span class="menu-item-label">Recent Files</span>
+            <span class="menu-item-shortcut">Ctrl+R</span>
+          </button>
           <div class="menu-separator"></div>
           <button class="menu-item" data-action="print">
             <span class="menu-item-label">Print</span>
@@ -70,24 +63,6 @@
       <div class="menu-dropdown">
         <button class="menu-btn" data-menu="view-menu">View</button>
         <div id="view-menu" class="menu-panel" hidden>
-          <button class="menu-item checkable" data-action="toggle-sync" data-checked="true">
-            <span class="menu-check">
-              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
-                <polyline points="2,6 5,9 10,3" />
-              </svg>
-            </span>
-            <span class="menu-item-label">Sync Scroll</span>
-            <span class="menu-item-shortcut">Alt+S</span>
-          </button>
-          <button class="menu-item checkable" data-action="toggle-line-numbers" data-checked="true">
-            <span class="menu-check">
-              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
-                <polyline points="2,6 5,9 10,3" />
-              </svg>
-            </span>
-            <span class="menu-item-label">Line Numbers</span>
-            <span class="menu-item-shortcut">Ctrl+L</span>
-          </button>
           <button class="menu-item checkable" data-action="toggle-word-wrap" data-checked="true">
             <span class="menu-check">
               <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
@@ -96,6 +71,24 @@
             </span>
             <span class="menu-item-label">Word Wrap</span>
             <span class="menu-item-shortcut">Alt+Z</span>
+          </button>
+          <button class="menu-item checkable" data-action="toggle-sync" data-checked="true">
+            <span class="menu-check">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="2,6 5,9 10,3" />
+              </svg>
+            </span>
+            <span class="menu-item-label">Sync Scroll</span>
+            <span class="menu-item-shortcut">Alt+X</span>
+          </button>
+          <button class="menu-item checkable" data-action="toggle-line-numbers" data-checked="true">
+            <span class="menu-check">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="2,6 5,9 10,3" />
+              </svg>
+            </span>
+            <span class="menu-item-label">Line Numbers</span>
+            <span class="menu-item-shortcut">Alt+C</span>
           </button>
           <button class="menu-item checkable" data-action="toggle-pb-visibility" data-checked="true">
             <span class="menu-check">
@@ -339,6 +332,10 @@
               <td>Save As</td>
             </tr>
             <tr>
+              <td><kbd>Ctrl</kbd>+<kbd>R</kbd></td>
+              <td>Recent files</td>
+            </tr>
+            <tr>
               <td><kbd>Ctrl</kbd>+<kbd>P</kbd></td>
               <td>Print</td>
             </tr>
@@ -351,20 +348,44 @@
               <td>Find and Replace</td>
             </tr>
             <tr>
-              <td><kbd>Ctrl</kbd>+<kbd>L</kbd></td>
-              <td>Toggle line numbers</td>
-            </tr>
-            <tr>
               <td><kbd>Alt</kbd>+<kbd>Z</kbd></td>
               <td>Toggle word wrap</td>
             </tr>
             <tr>
-              <td><kbd>Alt</kbd>+<kbd>S</kbd></td>
+              <td><kbd>Alt</kbd>+<kbd>X</kbd></td>
               <td>Toggle sync scroll</td>
+            </tr>
+            <tr>
+              <td><kbd>Alt</kbd>+<kbd>C</kbd></td>
+              <td>Toggle line numbers</td>
             </tr>
             <tr>
               <td><kbd>Alt</kbd>+<kbd>P</kbd></td>
               <td>Toggle page breaks</td>
+            </tr>
+            <tr>
+              <td><kbd>Alt</kbd>+<kbd>T</kbd> then <kbd>&uarr;</kbd>/<kbd>&darr;</kbd></td>
+              <td>Cycle theme</td>
+            </tr>
+            <tr>
+              <td><kbd>Alt</kbd>+<kbd>F</kbd> then <kbd>&uarr;</kbd>/<kbd>&darr;</kbd></td>
+              <td>Cycle font</td>
+            </tr>
+            <tr>
+              <td><kbd>Alt</kbd>+<kbd>D</kbd> then <kbd>&uarr;</kbd>/<kbd>&darr;</kbd></td>
+              <td>Cycle tab size</td>
+            </tr>
+            <tr>
+              <td><kbd>F11</kbd></td>
+              <td>Fullscreen preview</td>
+            </tr>
+            <tr>
+              <td><kbd>Ctrl</kbd>+<kbd>Q</kbd></td>
+              <td>Quit</td>
+            </tr>
+            <tr>
+              <td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd></td>
+              <td>Reload</td>
             </tr>
             <tr>
               <td><kbd>Ctrl</kbd>+<kbd>?</kbd></td>
@@ -372,6 +393,26 @@
             </tr>
           </tbody>
         </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- Recent Files Modal -->
+  <div id="recent-files-modal" class="modal-overlay" hidden>
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3>Recent Files</h3>
+        <button id="btn-close-recent" class="settings-close" aria-label="Close recent files">
+          <svg width="16" height="16" viewBox="0 0 12 12">
+            <line x1="2" y1="2" x2="10" y2="10" stroke="currentColor" stroke-width="1.5" />
+            <line x1="10" y1="2" x2="2" y2="10" stroke="currentColor" stroke-width="1.5" />
+          </svg>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div id="recent-files-list">
+          <div class="menu-item-empty">No recent files</div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/core/file-io.js
+++ b/src/core/file-io.js
@@ -5,7 +5,7 @@ import { config, saveConfig } from './config.js';
 import { isTauri } from './state.js';
 import { showUnsavedDialog } from '../ui/dialogs.js';
 import { updateTitleBar, updateStatusBar } from '../ui/status-bar.js';
-import { updateRecentFilesMenu } from '../ui/toolbar.js';
+import { updateRecentFilesList } from '../ui/toolbar.js';
 
 let _editorAPI = null;
 
@@ -182,7 +182,7 @@ function addToRecentFiles( path ) {
   config.recentFiles.unshift( path );
   if ( config.recentFiles.length > 10 ) config.recentFiles.pop();
   saveConfig();
-  updateRecentFilesMenu( config.recentFiles, onRecentFileSelect );
+  updateRecentFilesList( config.recentFiles, onRecentFileSelect );
 }
 
 /**

--- a/src/core/keyboard.js
+++ b/src/core/keyboard.js
@@ -2,15 +2,53 @@
 // editor toggles, and the shortcuts modal.
 
 import { config, saveConfig } from './config.js';
-import { openFile, saveFile, saveFileAs, newFile } from './file-io.js';
+import { openFile, saveFile, saveFileAs, newFile, confirmDiscardChanges } from './file-io.js';
 import { setSyncEnabled } from './sync.js';
-import { setMenuChecked } from '../ui/toolbar.js';
-import { toggleShortcutsModal } from '../ui/dialogs.js';
+import { setMenuChecked, setActiveFontFamily, setActiveTabSize } from '../ui/toolbar.js';
+import { toggleShortcutsModal, openRecentFilesModal } from '../ui/dialogs.js';
+import { cycleTheme } from '../ui/themes.js';
+import { toggleFullscreen, isFullscreenActive, exitFullscreen } from '../ui/fullscreen.js';
+import { closeWindow } from '../platform/window.js';
 
 let _editorAPI = null;
 
+// Cycle targets for the Alt-leader chords (Style menu mirrors these lists).
+const FONT_FAMILIES = [ "'JetBrains Mono', monospace", 'monospace' ];
+const TAB_SIZES = [ 2, 4 ];
+
+// Leader-key state for the Alt+T / Alt+F / Alt+D "then Up/Down" chords.
+let leader = null;
+let leaderTimer = null;
+const LEADER_WINDOW_MS = 2000;
+
 export function initKeyboardShortcuts( editorAPI ) {
   _editorAPI = editorAPI;
+
+  // Capture-phase handler for the leader chords. It runs before CodeMirror so
+  // Up/Down (and Alt+Up/Down) can drive theme/font/tab cycling without the
+  // editor also acting on the arrow keys. Inert unless a leader is armed.
+  document.addEventListener( 'keydown', ( e ) => {
+    if ( !leader ) return;
+
+    if ( e.key === 'ArrowUp' ) {
+      e.preventDefault();
+      e.stopPropagation();
+      cycleActiveLeader( 1 );
+    } else if ( e.key === 'ArrowDown' ) {
+      e.preventDefault();
+      e.stopPropagation();
+      cycleActiveLeader( -1 );
+    } else if ( e.key === 'Escape' ) {
+      e.preventDefault();
+      e.stopPropagation();
+      disarmLeader();
+    } else if ( e.key === 'Alt' || e.key === 'Shift' || e.key === 'Control' || e.key === 'Meta' ) {
+      // Bare modifier keydowns: keep the leader armed.
+    } else if ( !( e.altKey && ( e.key === 't' || e.key === 'f' || e.key === 'd' ) ) ) {
+      // Any other key cancels the chord (Alt+T/F/D re-arm via the main handler).
+      disarmLeader();
+    }
+  }, true );
 
   document.addEventListener( 'keydown', ( e ) => {
     const ctrl = e.ctrlKey || e.metaKey;
@@ -28,17 +66,24 @@ export function initKeyboardShortcuts( editorAPI ) {
     } else if ( ctrl && !shift && e.key === 'n' ) {
       e.preventDefault();
       newFile();
+    } else if ( ctrl && !shift && ( e.key === 'r' || e.key === 'R' ) ) {
+      e.preventDefault();
+      openRecentFilesModal();
+    } else if ( ctrl && shift && ( e.key === 'R' || e.key === 'r' ) ) {
+      e.preventDefault();
+      reloadApp();
+    } else if ( ctrl && !shift && ( e.key === 'q' || e.key === 'Q' ) ) {
+      e.preventDefault();
+      closeWindow();
     } else if ( ctrl && !shift && e.key === 'p' ) {
       e.preventDefault();
       window.print();
-    } else if ( ctrl && !shift && e.key === 'l' ) {
+    } else if ( e.key === 'F11' ) {
       e.preventDefault();
-      const current = config.lineNumbers !== false;
-      const next = !current;
-      _editorAPI.setLineNumbers( next );
-      config.lineNumbers = next;
-      saveConfig();
-      setMenuChecked( 'toggle-line-numbers', next );
+      toggleFullscreen();
+    } else if ( e.key === 'Escape' && isFullscreenActive() ) {
+      e.preventDefault();
+      exitFullscreen();
     } else if ( e.altKey && e.key === 'z' ) {
       e.preventDefault();
       const current = config.wordWrap !== false;
@@ -47,7 +92,7 @@ export function initKeyboardShortcuts( editorAPI ) {
       config.wordWrap = next;
       saveConfig();
       setMenuChecked( 'toggle-word-wrap', next );
-    } else if ( e.altKey && e.key === 's' ) {
+    } else if ( e.altKey && e.key === 'x' ) {
       e.preventDefault();
       const current = config.syncScroll !== false;
       const next = !current;
@@ -55,6 +100,14 @@ export function initKeyboardShortcuts( editorAPI ) {
       config.syncScroll = next;
       saveConfig();
       setMenuChecked( 'toggle-sync', next );
+    } else if ( e.altKey && e.key === 'c' ) {
+      e.preventDefault();
+      const current = config.lineNumbers !== false;
+      const next = !current;
+      _editorAPI.setLineNumbers( next );
+      config.lineNumbers = next;
+      saveConfig();
+      setMenuChecked( 'toggle-line-numbers', next );
     } else if ( e.altKey && e.key === 'p' ) {
       e.preventDefault();
       const current = config.showPageBreaks !== false;
@@ -70,6 +123,15 @@ export function initKeyboardShortcuts( editorAPI ) {
           previewPane.classList.add( 'hide-pb-markers' );
         }
       }
+    } else if ( e.altKey && e.key === 't' ) {
+      e.preventDefault();
+      armLeader( 'theme' );
+    } else if ( e.altKey && e.key === 'f' ) {
+      e.preventDefault();
+      armLeader( 'font' );
+    } else if ( e.altKey && e.key === 'd' ) {
+      e.preventDefault();
+      armLeader( 'tab' );
     } else if ( ctrl && ( e.key === '?' || ( shift && e.key === '/' ) ) ) {
       e.preventDefault();
       toggleShortcutsModal();
@@ -123,6 +185,62 @@ export function initKeyboardShortcuts( editorAPI ) {
       }
     }
   }, { passive: false } );
+}
+
+// ---- Alt-leader chord helpers (theme / font / tab cycling) ----
+
+function armLeader( name ) {
+  leader = name;
+  clearTimeout( leaderTimer );
+  leaderTimer = setTimeout( () => { leader = null; }, LEADER_WINDOW_MS );
+}
+
+function disarmLeader() {
+  leader = null;
+  clearTimeout( leaderTimer );
+}
+
+function cycleActiveLeader( direction ) {
+  if ( leader === 'theme' ) {
+    cycleTheme( direction );
+  } else if ( leader === 'font' ) {
+    cycleFont( direction );
+  } else if ( leader === 'tab' ) {
+    cycleTab( direction );
+  }
+  // Re-arm so the user can keep pressing Up/Down within the window.
+  armLeader( leader );
+}
+
+function cycleFont( direction ) {
+  const cur = config.fontFamily || FONT_FAMILIES[ 0 ];
+  let idx = FONT_FAMILIES.indexOf( cur );
+  if ( idx === -1 ) idx = 0;
+  const next = FONT_FAMILIES[ ( idx + direction + FONT_FAMILIES.length ) % FONT_FAMILIES.length ];
+  document.documentElement.style.setProperty( '--font-mono', next );
+  config.fontFamily = next;
+  saveConfig();
+  setActiveFontFamily( next );
+  _editorAPI.requestMeasure();
+}
+
+function cycleTab( direction ) {
+  const cur = config.tabSize || 4;
+  let idx = TAB_SIZES.indexOf( cur );
+  if ( idx === -1 ) idx = TAB_SIZES.indexOf( 4 );
+  const next = TAB_SIZES[ ( idx + direction + TAB_SIZES.length ) % TAB_SIZES.length ];
+  _editorAPI.setTabSize( next );
+  config.tabSize = next;
+  saveConfig();
+  setActiveTabSize( next );
+}
+
+// Guarded reload (Ctrl+Shift+R): warn on unsaved changes, then re-run boot from
+// persisted config.
+async function reloadApp() {
+  if ( await confirmDiscardChanges() ) {
+    window.location.reload();
+  }
 }
 
 export function updateZoomBadge( size ) {

--- a/src/core/welcome.js
+++ b/src/core/welcome.js
@@ -1,59 +1,51 @@
-export const WELCOME_TEXT = `# Welcome to the Markdown Editor
+export const WELCOME_TEXT = `# Welcome to Feather MD
 
-This editor is a lightweight Markdown writer designed for clean formatting. You can write using standard Markdown syntax, and it will render real-time HTML formatting on the fly.
+A fast, native dual-pane editor: you write on the left, the live preview renders on the right with scroll sync. You already know Markdown — here is what is specific to this app.
 
----
+## Page breaks
 
-## Getting Started
-
-Use this default sandbox document to experiment with Markdown formatting. Here is a demonstration of the major supported elements:
-
-### 1. Typography & Inline Styles
-Format your text dynamically using:
-* **Bold text** for emphasis
-* *Italicized text* for styling
-* ~~Strikethrough~~ to cross out items
-* \`Inline code blocks\` for technical variables
-* [Hyperlinks](https://en.wikipedia.org/wiki/Markdown) pointing to web addresses
-
-> **Quote blocks** are structured with a vertical margin line to highlight references, warnings, or detailed side notes.
-
-### 2. Page Breaks
-You can control page breaks when printing/saving to PDF by inserting the \`<pb>\` tag. This creates a clean page boundary in PDF output. You can toggle the marker visibility in the preview pane using the **View** menu or by pressing \`Alt + P\` for distraction-free reading.
+Drop a \`<pb>\` tag anywhere to force a clean page boundary when printing or exporting to PDF. Toggle the marker's visibility with \`Alt + P\` for distraction-free reading.
 
 <pb>
 
-### 3. Lists & Checklists
-Organize your tasks or outlines:
-1. First structured item
-   - Bulleted sub-point
-   - Secondary sub-point
-2. Second structured item
+## Syntax highlighting
 
-- [x] Completed task item
-- [ ] Remaining task item
+Fenced code blocks are highlighted on demand — hundreds of languages, each loaded only the first time you use it, so startup stays instant.
 
-### 4. Syntax-Highlighted Code
-Write block code snippet elements with language syntax mapping:
-
-\`\`\`javascript
-// Live preview rendering loop
-function renderTemplate() {
-  const content = "Hello world!";
-  console.log(content);
+\`\`\`js
+function render(markdown) {
+  return preview(markdown); // updates as you type
 }
 \`\`\`
 
-### 5. Structured Tables
-Summarize datasets easily:
+## Make it yours
 
-| Element Type | Syntax Example | Render Output |
-| :--- | :--- | :--- |
-| Headers | \`# Header 1\` | Styled Title Heading |
-| Accent | \`*Text*\` | Slanted Typography |
-| Highlight | \`\`Code\`\` | Monospaced Text |
+Cycle settings without touching the mouse: tap a leader key, then \`↑\` / \`↓\`.
+
+| Shortcut | Action |
+| :--- | :--- |
+| \`Alt + T\` then ↑ / ↓ | Cycle theme (5 light, 5 dark) |
+| \`Alt + F\` then ↑ / ↓ | Cycle font |
+| \`Alt + D\` then ↑ / ↓ | Cycle tab size |
+| \`Ctrl\` + scroll | Zoom text in / out |
+
+## Get around
+
+| Shortcut | Action |
+| :--- | :--- |
+| \`Ctrl + O\` / \`Ctrl + R\` | Open / Recent files |
+| \`Ctrl + S\` / \`Ctrl + Shift + S\` | Save / Save As |
+| \`Alt + Z\` · \`Alt + X\` · \`Alt + C\` | Word wrap · Sync scroll · Line numbers |
+| \`F11\` | Fullscreen preview (\`Esc\` exits) |
+| \`Ctrl + P\` | Print / export to PDF |
+| \`Ctrl + ?\` | Every shortcut |
+
+## Good to know
+
+- Edit the open file in another program and Feather MD reloads it for you — it asks first if you have unsaved changes.
+- Everything stays local. No accounts, no telemetry, no background services.
 
 ---
 
-*Press \`Ctrl + ?\` at any time to view all available system keyboard shortcuts.*
+*This is just a scratch pad — clear it and start writing.*
 `;

--- a/src/main.js
+++ b/src/main.js
@@ -33,9 +33,9 @@ import {
   setActiveTheme,
   setActiveFontFamily,
   setActiveTabSize,
-  updateRecentFilesMenu,
+  updateRecentFilesList,
 } from './ui/toolbar.js';
-import { initShortcutsModal, showUnsavedDialog } from './ui/dialogs.js';
+import { initShortcutsModal, initRecentFilesModal, openRecentFilesModal, showUnsavedDialog } from './ui/dialogs.js';
 import { initStatusBar, updateTitleBar, updateStatusBar, updateCursorPosition } from './ui/status-bar.js';
 import { initDividerDrag } from './ui/divider.js';
 
@@ -67,6 +67,7 @@ window.addEventListener('DOMContentLoaded', () => {
   initDividerDrag();
   initKeyboardShortcuts(editorAPI);
   initShortcutsModal();
+  initRecentFilesModal();
 
   const headerIcon = document.getElementById('header-icon');
   if (headerIcon) {
@@ -118,13 +119,14 @@ async function runBootSequence() {
     saveConfig();
   });
 
-  updateRecentFilesMenu(config.recentFiles || [], onRecentFileSelect);
+  updateRecentFilesList(config.recentFiles || [], onRecentFileSelect);
 
   initToolbar({
     onOpen: openFile,
     onSave: saveFile,
     onSaveAs: saveFileAs,
     onNew: newFile,
+    onRecentFiles: openRecentFilesModal,
     onPrint: () => window.print(),
     onSyncToggle: (enabled) => {
       setSyncEnabled(enabled);

--- a/src/platform/window.js
+++ b/src/platform/window.js
@@ -57,6 +57,56 @@ export async function ensureWindowVisible() {
   }
 }
 
+/**
+ * Read the current maximized state. Returns false in browser dev mode or on
+ * error so callers can treat it as "not maximized".
+ */
+export async function getWindowMaximized() {
+  if ( !isTauri() ) return false;
+  try {
+    const { getCurrentWindow } = await import( '@tauri-apps/api/window' );
+    return await getCurrentWindow().isMaximized();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Maximize / unmaximize the window. Used by fullscreen preview mode (F11):
+ * maximizing fills the work area (taskbar stays visible) and reliably resizes
+ * the WebView, unlike OS borderless fullscreen which leaves a native-background
+ * gap where the WebView lags the window. No-op in browser dev mode.
+ */
+export async function setWindowMaximized( on ) {
+  if ( !isTauri() ) return;
+  try {
+    const { getCurrentWindow } = await import( '@tauri-apps/api/window' );
+    const appWindow = getCurrentWindow();
+    if ( on ) {
+      await appWindow.maximize();
+    } else {
+      await appWindow.unmaximize();
+    }
+  } catch ( err ) {
+    console.warn( 'Failed to toggle window maximize:', err );
+  }
+}
+
+/**
+ * Request a window close (Ctrl+Q). Routes through Tauri's close, which fires
+ * the onCloseRequested handler wired in main.js so the unsaved-changes guard
+ * still runs. No-op in browser dev mode.
+ */
+export async function closeWindow() {
+  if ( !isTauri() ) return;
+  try {
+    const { getCurrentWindow } = await import( '@tauri-apps/api/window' );
+    await getCurrentWindow().close();
+  } catch ( err ) {
+    console.warn( 'Failed to close window:', err );
+  }
+}
+
 export async function initWindowSize() {
   if ( !isTauri() ) return;
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -314,12 +314,20 @@ html, body {
   transform: translateX(2px);
 }
 
-/* Recent file items in submenu */
-.recent-submenu-item {
+/* Recent file items (Recent Files modal) */
+#recent-files-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 50vh;
+  overflow-y: auto;
+}
+
+.recent-file-item {
   display: flex;
   flex-direction: column;
   width: 100%;
-  padding: 6px 10px;
+  padding: 8px 10px;
   background: transparent;
   border: none;
   color: var(--text);
@@ -332,18 +340,18 @@ html, body {
   gap: 2px;
 }
 
-.recent-submenu-item:hover {
+.recent-file-item:hover {
   background: color-mix(in srgb, var(--text) 8%, transparent);
 }
 
-.recent-submenu-name {
+.recent-file-name {
   font-weight: 500;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.recent-submenu-path {
+.recent-file-path {
   font-size: 10px;
   color: var(--text-muted);
   white-space: nowrap;
@@ -865,6 +873,55 @@ body.resizing {
 
 .update-btn-secondary:hover {
   background: rgba(255, 255, 255, 0.3);
+}
+
+/* ---- Fullscreen Preview Mode (F11) ----
+   Distraction-free, preview-only surface: hide all chrome and let the preview
+   pane fill the window. Toggled by adding `fullscreen-preview` to <body>. */
+body.fullscreen-preview #header-bar,
+body.fullscreen-preview #editor-pane,
+body.fullscreen-preview #divider,
+body.fullscreen-preview #status-bar {
+  display: none !important;
+}
+
+/* Pin to the real viewport (not 100vh, which goes stale when the window grows
+   to OS fullscreen and leaves a native-background gap at the bottom) and paint
+   the theme background so no unpainted region can show through. */
+body.fullscreen-preview #split-container {
+  position: fixed;
+  inset: 0;
+  height: auto;
+  background: var(--bg);
+}
+
+body.fullscreen-preview #preview-pane {
+  width: 100% !important;
+  max-width: 100% !important;
+}
+
+#fullscreen-hint {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: color-mix(in srgb, var(--text) 85%, transparent);
+  color: var(--bg);
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.2px;
+  z-index: 400;
+  opacity: 0;
+  pointer-events: none;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  transition: opacity 300ms ease;
+}
+
+#fullscreen-hint.show {
+  opacity: 1;
 }
 
 /* ========================================

--- a/src/ui/dialogs.js
+++ b/src/ui/dialogs.js
@@ -92,3 +92,29 @@ export function initShortcutsModal() {
     if ( e.target === modal ) modal.hidden = true;
   } );
 }
+
+export function openRecentFilesModal() {
+  const modal = document.getElementById( 'recent-files-modal' );
+  if ( modal ) modal.hidden = false;
+}
+
+export function closeRecentFilesModal() {
+  const modal = document.getElementById( 'recent-files-modal' );
+  if ( modal ) modal.hidden = true;
+}
+
+export function initRecentFilesModal() {
+  const modal = document.getElementById( 'recent-files-modal' );
+  const closeBtn = document.getElementById( 'btn-close-recent' );
+  closeBtn?.addEventListener( 'click', closeRecentFilesModal );
+  modal?.addEventListener( 'click', ( e ) => {
+    if ( e.target === modal ) closeRecentFilesModal();
+  } );
+  // Keyboard-first: Escape dismisses the modal while it is open.
+  document.addEventListener( 'keydown', ( e ) => {
+    if ( e.key === 'Escape' && modal && !modal.hidden ) {
+      e.preventDefault();
+      closeRecentFilesModal();
+    }
+  } );
+}

--- a/src/ui/fullscreen.js
+++ b/src/ui/fullscreen.js
@@ -1,0 +1,66 @@
+// Fullscreen preview mode (F11).
+//
+// Toggles a distraction-free, preview-only surface: the body gains the
+// `fullscreen-preview` class (CSS hides the header, editor, divider, and status
+// bar so only the preview remains), and — under Tauri — the window is maximized
+// so the preview fills the work area. Maximize (rather than OS borderless
+// fullscreen) is deliberate: borderless fullscreen on Windows resizes the
+// window ahead of the WebView, leaving a taskbar-height strip of native (black)
+// window background that no CSS can cover. Maximize keeps the taskbar visible
+// and resizes the WebView cleanly. Ctrl+scroll zoom keeps working because both
+// panes are sized from the shared `--font-size` variable.
+
+import { getWindowMaximized, setWindowMaximized } from '../platform/window.js';
+
+let active = false;
+let hintTimer = null;
+// Remembers whether the window was already maximized on entry, so exiting
+// restores the prior state instead of always unmaximizing.
+let wasMaximized = false;
+
+export function isFullscreenActive() {
+  return active;
+}
+
+export function toggleFullscreen() {
+  return active ? exitFullscreen() : enterFullscreen();
+}
+
+export async function enterFullscreen() {
+  if ( active ) return;
+  active = true;
+  wasMaximized = await getWindowMaximized();
+  document.body.classList.add( 'fullscreen-preview' );
+  showHint();
+  await setWindowMaximized( true );
+}
+
+export async function exitFullscreen() {
+  if ( !active ) return;
+  active = false;
+  document.body.classList.remove( 'fullscreen-preview' );
+  hideHint();
+  if ( !wasMaximized ) await setWindowMaximized( false );
+}
+
+// A small auto-fading hint so the user is never stranded with no visible chrome.
+function showHint() {
+  let hint = document.getElementById( 'fullscreen-hint' );
+  if ( !hint ) {
+    hint = document.createElement( 'div' );
+    hint.id = 'fullscreen-hint';
+    document.body.appendChild( hint );
+  }
+  hint.textContent = 'Press Esc or F11 to exit fullscreen';
+  // Force reflow so the fade-in animation restarts on repeated entries.
+  void hint.offsetWidth;
+  hint.classList.add( 'show' );
+  clearTimeout( hintTimer );
+  hintTimer = setTimeout( () => hint.classList.remove( 'show' ), 2500 );
+}
+
+function hideHint() {
+  clearTimeout( hintTimer );
+  const hint = document.getElementById( 'fullscreen-hint' );
+  if ( hint ) hint.classList.remove( 'show' );
+}

--- a/src/ui/themes.js
+++ b/src/ui/themes.js
@@ -78,3 +78,16 @@ export function setTheme( name ) {
   userPickedTheme = true;
   applyTheme( name );
 }
+
+/**
+ * Cycle to the next/previous theme in THEMES order and apply it.
+ * @param {number} direction - +1 forward, -1 backward
+ * @returns {string} the newly applied theme name
+ */
+export function cycleTheme( direction ) {
+  const idx = THEMES.indexOf( currentTheme );
+  const start = idx === -1 ? 0 : idx;
+  const next = THEMES[ ( start + direction + THEMES.length ) % THEMES.length ];
+  setTheme( next );
+  return next;
+}

--- a/src/ui/toolbar.js
+++ b/src/ui/toolbar.js
@@ -83,6 +83,7 @@ export function initToolbar( handlers ) {
   wireAction( 'open-file', () => { handlers.onOpen(); closeAllMenus(); } );
   wireAction( 'save-file', () => { handlers.onSave(); closeAllMenus(); } );
   wireAction( 'save-as', () => { handlers.onSaveAs(); closeAllMenus(); } );
+  wireAction( 'recent-files', () => { handlers.onRecentFiles(); closeAllMenus(); } );
   wireAction( 'print', () => { handlers.onPrint(); closeAllMenus(); } );
 
   // View menu toggles
@@ -200,10 +201,11 @@ export function setActiveTabSize( size ) {
 
 
 /**
- * Update recent files in the submenu
+ * Render the recent-files list into the Recent Files modal. Selecting an item
+ * closes the modal and invokes the open-file callback.
  */
-export function updateRecentFilesMenu( recentFiles, onFileSelect ) {
-  const container = document.getElementById( 'recent-files-submenu' );
+export function updateRecentFilesList( recentFiles, onFileSelect ) {
+  const container = document.getElementById( 'recent-files-list' );
   if ( !container ) return;
 
   if ( !recentFiles || recentFiles.length === 0 ) {
@@ -217,15 +219,16 @@ export function updateRecentFilesMenu( recentFiles, onFileSelect ) {
     const name = parts.pop() || 'Untitled';
 
     const btn = document.createElement( 'button' );
-    btn.className = 'recent-submenu-item';
+    btn.className = 'recent-file-item';
     btn.innerHTML = `
-      <span class="recent-submenu-name" title="${ escapeHtml( name ) }">${ escapeHtml( name ) }</span>
-      <span class="recent-submenu-path" title="${ escapeHtml( filePath ) }">${ escapeHtml( filePath ) }</span>
+      <span class="recent-file-name" title="${ escapeHtml( name ) }">${ escapeHtml( name ) }</span>
+      <span class="recent-file-path" title="${ escapeHtml( filePath ) }">${ escapeHtml( filePath ) }</span>
     `;
     btn.addEventListener( 'click', ( e ) => {
       e.stopPropagation();
+      const modal = document.getElementById( 'recent-files-modal' );
+      if ( modal ) modal.hidden = true;
       if ( onFileSelect ) onFileSelect( filePath );
-      closeAllMenus();
     } );
     container.appendChild( btn );
   } );

--- a/tests/html.test.js
+++ b/tests/html.test.js
@@ -54,8 +54,8 @@ describe('HTML -- Required Element IDs', () => {
     // Menus
     'file-menu', 'view-menu', 'style-menu',
 
-    // Recent files submenu
-    'recent-files-submenu',
+    // Recent files modal
+    'recent-files-modal', 'recent-files-list', 'btn-close-recent',
     // Split container
     'split-container', 'editor-pane', 'divider', 'preview-pane', 'preview-content',
     // Shortcuts modal
@@ -83,6 +83,7 @@ describe('HTML -- Accessibility (ARIA labels)', () => {
     { id: 'btn-maximize', label: 'Maximize' },
     { id: 'btn-close', label: 'Close' },
     { id: 'btn-close-shortcuts', label: 'Close shortcuts' },
+    { id: 'btn-close-recent', label: 'Close recent files' },
   ];
 
   labelledButtons.forEach(({ id, label }) => {
@@ -155,6 +156,10 @@ describe('HTML -- Modals Initial State', () => {
 
   it('should start with unsaved dialog hidden', () => {
     expect(doc.getElementById('unsaved-dialog').hasAttribute('hidden')).toBe(true);
+  });
+
+  it('should start with recent files modal hidden', () => {
+    expect(doc.getElementById('recent-files-modal').hasAttribute('hidden')).toBe(true);
   });
 });
 

--- a/tests/ui/fullscreen.test.js
+++ b/tests/ui/fullscreen.test.js
@@ -1,0 +1,85 @@
+// ========================================
+// Feather MD -- Fullscreen Preview Mode Tests
+// ========================================
+// Covers: enter/exit toggling, body class, active-state tracking, and the
+// auto-fading exit hint. The Tauri window call is a no-op outside Tauri
+// (isTauri() === false in jsdom), so these run purely on the DOM.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  toggleFullscreen,
+  enterFullscreen,
+  exitFullscreen,
+  isFullscreenActive,
+} from '../../src/ui/fullscreen.js';
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  // Reset to a known non-fullscreen state between tests.
+  await exitFullscreen();
+  document.body.className = '';
+  const hint = document.getElementById('fullscreen-hint');
+  if (hint) hint.remove();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('Fullscreen -- Enter / Exit', () => {
+  it('should start inactive', () => {
+    expect(isFullscreenActive()).toBe(false);
+  });
+
+  it('should add the fullscreen-preview class on enter', async () => {
+    await enterFullscreen();
+    expect(document.body.classList.contains('fullscreen-preview')).toBe(true);
+    expect(isFullscreenActive()).toBe(true);
+  });
+
+  it('should remove the fullscreen-preview class on exit', async () => {
+    await enterFullscreen();
+    await exitFullscreen();
+    expect(document.body.classList.contains('fullscreen-preview')).toBe(false);
+    expect(isFullscreenActive()).toBe(false);
+  });
+
+  it('should toggle on then off', async () => {
+    await toggleFullscreen();
+    expect(isFullscreenActive()).toBe(true);
+    await toggleFullscreen();
+    expect(isFullscreenActive()).toBe(false);
+  });
+
+  it('should be idempotent when entering twice', async () => {
+    await enterFullscreen();
+    await enterFullscreen();
+    expect(isFullscreenActive()).toBe(true);
+    await exitFullscreen();
+    expect(isFullscreenActive()).toBe(false);
+  });
+});
+
+describe('Fullscreen -- Exit Hint', () => {
+  it('should show a hint element on enter', async () => {
+    await enterFullscreen();
+    const hint = document.getElementById('fullscreen-hint');
+    expect(hint).toBeTruthy();
+    expect(hint.classList.contains('show')).toBe(true);
+    expect(hint.textContent).toContain('exit fullscreen');
+  });
+
+  it('should auto-hide the hint after the timeout', async () => {
+    await enterFullscreen();
+    vi.advanceTimersByTime(2600);
+    const hint = document.getElementById('fullscreen-hint');
+    expect(hint.classList.contains('show')).toBe(false);
+  });
+
+  it('should hide the hint immediately on exit', async () => {
+    await enterFullscreen();
+    await exitFullscreen();
+    const hint = document.getElementById('fullscreen-hint');
+    expect(hint.classList.contains('show')).toBe(false);
+  });
+});

--- a/tests/ui/themes.test.js
+++ b/tests/ui/themes.test.js
@@ -5,7 +5,7 @@
 //         theme validation, menu active state sync, all 10 themes enumeration
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { initThemes, setTheme, applyTheme } from '../../src/ui/themes.js';
+import { initThemes, setTheme, applyTheme, cycleTheme } from '../../src/ui/themes.js';
 
 const THEMES = ['snow', 'solarized-light', 'github-light', 'sepia', 'gruvbox-light', 'onyx', 'solarized-dark', 'github-dark', 'monokai', 'gruvbox-dark'];
 
@@ -179,6 +179,40 @@ describe('Themes -- Menu Active State Sync', () => {
     setTheme('gruvbox-dark');
     expect(document.querySelector('.theme-item[data-theme="sepia"]').getAttribute('data-checked')).toBe('false');
     expect(document.querySelector('.theme-item[data-theme="gruvbox-dark"]').getAttribute('data-checked')).toBe('true');
+  });
+});
+
+// -- Theme Cycling (Alt+T leader chord) --
+
+describe('Themes -- Cycling', () => {
+  beforeEach(() => setupThemeDOM(false));
+
+  it('should advance to the next theme when cycling forward', () => {
+    initThemes(null); // snow (index 0)
+    const next = cycleTheme(1);
+    expect(next).toBe('solarized-light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('solarized-light');
+  });
+
+  it('should wrap to the last theme when cycling backward from the first', () => {
+    initThemes(null); // snow (index 0)
+    const prev = cycleTheme(-1);
+    expect(prev).toBe('gruvbox-dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('gruvbox-dark');
+  });
+
+  it('should wrap to the first theme when cycling forward from the last', () => {
+    initThemes({ theme: 'gruvbox-dark' });
+    const next = cycleTheme(1);
+    expect(next).toBe('snow');
+  });
+
+  it('should persist the cycled theme via the change callback', () => {
+    const spy = vi.fn();
+    initThemes(null, spy);
+    spy.mockClear();
+    cycleTheme(1);
+    expect(spy).toHaveBeenCalledWith('solarized-light');
   });
 });
 

--- a/tests/ui/toolbar.test.js
+++ b/tests/ui/toolbar.test.js
@@ -11,7 +11,7 @@ import {
   setActiveTheme,
   setActiveFontFamily,
   setActiveTabSize,
-  updateRecentFilesMenu,
+  updateRecentFilesList,
 } from '../../src/ui/toolbar.js';
 
 /**
@@ -36,14 +36,9 @@ function setupMenuBarDOM() {
             <button class="menu-item" data-action="save-as">
               <span class="menu-item-label">Save As</span>
             </button>
-            <div class="menu-submenu">
-              <button class="menu-item has-submenu" data-action="recent-files">
-                <span class="menu-item-label">Recent Files</span>
-              </button>
-              <div class="submenu-panel" id="recent-files-submenu">
-                <div class="menu-item-empty">No recent files</div>
-              </div>
-            </div>
+            <button class="menu-item" data-action="recent-files">
+              <span class="menu-item-label">Recent Files</span>
+            </button>
             <button class="menu-item" data-action="print">
               <span class="menu-item-label">Print</span>
             </button>
@@ -98,6 +93,11 @@ function setupMenuBarDOM() {
 
       </div>
     </div>
+    <div id="recent-files-modal" class="modal-overlay" hidden>
+      <div id="recent-files-list">
+        <div class="menu-item-empty">No recent files</div>
+      </div>
+    </div>
   `;
 }
 
@@ -107,6 +107,7 @@ function createHandlers() {
     onSave: vi.fn(),
     onSaveAs: vi.fn(),
     onNew: vi.fn(),
+    onRecentFiles: vi.fn(),
     onPrint: vi.fn(),
     onSyncToggle: vi.fn(),
     onThemeSelect: vi.fn(),
@@ -152,6 +153,11 @@ describe('Toolbar -- File Menu Actions', () => {
   it('should fire onPrint when Print action is clicked', () => {
     document.querySelector('[data-action="print"]').click();
     expect(handlers.onPrint).toHaveBeenCalledOnce();
+  });
+
+  it('should fire onRecentFiles when Recent Files action is clicked', () => {
+    document.querySelector('[data-action="recent-files"]').click();
+    expect(handlers.onRecentFiles).toHaveBeenCalledOnce();
   });
 });
 
@@ -299,30 +305,38 @@ describe('Toolbar -- setActiveTheme Utility', () => {
 
 
 
-// -- updateRecentFilesMenu Utility --
+// -- updateRecentFilesList Utility --
 
-describe('Toolbar -- updateRecentFilesMenu', () => {
+describe('Toolbar -- updateRecentFilesList', () => {
   beforeEach(() => setupMenuBarDOM());
 
   it('should show empty message when no recent files', () => {
-    updateRecentFilesMenu([], vi.fn());
-    const container = document.getElementById('recent-files-submenu');
+    updateRecentFilesList([], vi.fn());
+    const container = document.getElementById('recent-files-list');
     expect(container.querySelector('.menu-item-empty')).toBeTruthy();
   });
 
   it('should render recent file items', () => {
-    updateRecentFilesMenu(['/path/to/file.md', '/path/to/other.md'], vi.fn());
-    const container = document.getElementById('recent-files-submenu');
-    const items = container.querySelectorAll('.recent-submenu-item');
+    updateRecentFilesList(['/path/to/file.md', '/path/to/other.md'], vi.fn());
+    const container = document.getElementById('recent-files-list');
+    const items = container.querySelectorAll('.recent-file-item');
     expect(items.length).toBe(2);
   });
 
   it('should fire callback when a recent file is clicked', () => {
     const spy = vi.fn();
-    updateRecentFilesMenu(['/path/to/file.md'], spy);
-    const container = document.getElementById('recent-files-submenu');
-    container.querySelector('.recent-submenu-item').click();
+    updateRecentFilesList(['/path/to/file.md'], spy);
+    const container = document.getElementById('recent-files-list');
+    container.querySelector('.recent-file-item').click();
     expect(spy).toHaveBeenCalledWith('/path/to/file.md');
+  });
+
+  it('should close the recent files modal when an item is selected', () => {
+    const modal = document.getElementById('recent-files-modal');
+    modal.hidden = false;
+    updateRecentFilesList(['/path/to/file.md'], vi.fn());
+    document.getElementById('recent-files-list').querySelector('.recent-file-item').click();
+    expect(modal.hidden).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a distraction-free fullscreen preview mode (F11) and overhauls the keyboard scheme for a mouse-free, muscle-memory workflow. Sync-scroll moves to Alt+X and line-numbers to Alt+C; theme/font/tab size now cycle via Alt+T/F/D leader chords (then Up/Down); Recent Files becomes a modal (Ctrl+R) instead of a hover submenu; and Ctrl+Q (quit) and Ctrl+Shift+R (reload) are added. Docs and the in-app shortcuts reference are updated to match. Note: the previous Alt+S (sync) and Ctrl+L (line numbers) bindings are intentionally replaced, not aliased.

Closes #15 #2 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Breaking change
- [ ] Documentation only
- [ ] Build, CI, or tooling


## Checklist

- [x] My change keeps the bundle and binary size budgets in mind.
- [x] No new runtime dependency without a clear reason.
- [x] Tauri imports stay inside `src/platform/` or `src-tauri/`.
- [x] Tests added or updated for new behavior.
- [x] Commit messages follow `type(scope): description`.