### PR TITLE
chore(updater): enable quiet Windows installer mode and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Release bundles land in:
 | **Custom unsaved-changes modal** | Save / Don't Save / Cancel with single-key shortcuts (`S` / `N` / `C`), Tab nav, and Enter to confirm. |
 | **CLI launch** | `feathermd <path>` opens a file directly. Useful from a terminal or a shell hotkey. |
 | **OS file associations** | `.md` and `.markdown` open in Feather MD on double-click. |
-| **Signed auto-updates** | Ed25519-signed auto-update check on startup with a minimalist slide-in banner and one-click install. |
+| **Signed background auto-updates** | Ed25519-signed update check on startup that downloads and stages quietly in the background. Status shows in the status-bar version text (`Updating...` → `Restart App!`); restarting runs the unsaved-changes guard first. No banners. |
 | **Persistent preferences** | Theme, font family, font size, tab size, line numbers, word wrap, scroll-sync, split ratio, window size, and maximized state are all restored on launch. |
 | **No startup flash** | Window stays hidden until persisted size is applied — no wrong-size flicker. |
 
@@ -174,7 +174,7 @@ If you are managing thousands of linked notes with backlinks and graphs, you wan
 | `F11` | Fullscreen preview (`Esc` exits) |
 | `Ctrl + Q` | Quit |
 | `Ctrl + Shift + R` | Reload |
-| `Ctrl + ?` | Show all shortcuts |
+| `Ctrl + .` | Show all shortcuts |
 
 The theme/font/tab-size chords are a leader sequence: tap `Alt + T` (or `F` / `D`), then `↑` / `↓` to cycle within a short window.
 
@@ -212,7 +212,8 @@ featherMD/
 │   │   │                            and shortcuts help modal.
 │   │   ├── status-bar.js            Word count, cursor position, file path,
 │   │   │                            line ending.
-│   │   └── divider.js               Editor/preview split-pane drag handle.
+│   │   ├── divider.js               Editor/preview split-pane drag handle.
+│   │   └── fullscreen.js            F11 distraction-free preview mode.
 │   │
 │   ├── core/
 │   │   ├── config.js                Defaults + Tauri appConfigDir /
@@ -231,7 +232,8 @@ featherMD/
 │   ├── platform/
 │   │   ├── window.js                Tauri window controls, size persistence,
 │   │   │                            deferred show().
-│   │   └── updater.js               Ed25519-verified auto-update banner.
+│   │   └── updater.js               Ed25519-verified background auto-update;
+│   │                                status-bar update phases + guarded relaunch.
 │   │
 │   └── styles/
 │       ├── base.css                 Layout, header, status bar, modals,
@@ -243,10 +245,11 @@ featherMD/
 ├── src-tauri/                       Rust backend.
 │   ├── src/
 │   │   ├── main.rs                  Tauri app entry (windows_subsystem guard).
-│   │   └── lib.rs                   IPC commands: get_initial_file,
-│   │                                watch_file, unwatch_file. Event-driven
-│   │                                file watcher via the `notify` crate
-│   │                                (no polling timers).
+│   │   └── lib.rs                   IPC commands: get_initial_file, watch_file,
+│   │                                unwatch_file, tray_active, set_tray,
+│   │                                set_webview_memory. Event-driven file watcher
+│   │                                via the `notify` crate (no polling timers);
+│   │                                system tray + WebView2 working-set trim.
 │   ├── capabilities/
 │   │   └── default.json             Tauri 2 permission scopes for plugins.
 │   ├── icons/                       Platform icons.
@@ -272,9 +275,9 @@ featherMD/
 │
 ├── scripts/
 │   ├── generate-report.js           Full audit: build + lint + tests + bench.
-│   └── version-bump.js              Sync version across package.json /
-│                                    Cargo.toml / Cargo.lock /
-│                                    tauri.conf.json / base.css.
+│   └── version-bump.js              Sync version from package.json into
+│                                    tauri.conf.json / Cargo.toml / Cargo.lock /
+│                                    index.html / page/ landing page.
 │
 ├── page/                            GitHub Pages landing page.
 ├── .github/                         Issue templates, PR templates, CI workflows.

--- a/artifacts/docs/PRD.md
+++ b/artifacts/docs/PRD.md
@@ -1,8 +1,8 @@
 # PRD - Feather MD
 ### Lightweight Dual-Pane Markdown Editor for Windows & Linux
-**Version:** 1.9.0
-**Status:** Shipping (1.9.0 released 2026-06-17)
-**Last updated:** 2026-06-17
+**Version:** 1.10.1
+**Status:** Shipping (1.10.0 introduced the background auto-update flow; 1.10.1 current)
+**Last updated:** 2026-06-19
 
 ---
 
@@ -130,7 +130,7 @@ Theme auto-detection: reads `window.matchMedia('(prefers-color-scheme: dark)')` 
 - Resizable split: drag the central divider; clamped 20% / 80% per pane; double-click resets to 50/50; ratio persisted
 - Status bar (bottom, 26 px):
   - Left: file path (truncated, hover-tooltip with full path)
-  - Right: selected statistics (word, character, and paragraph count shown dynamically as `(x words, y chars, z paras) sel` when text is highlighted) · total word count · total character count · total paragraph count · Ln/Col · UTF-8 encoding · LF/CRLF indicator · version link pointing to GitHub on the extreme right
+  - Right: selected statistics (word, character, and paragraph count shown dynamically as `(x words, y chars, z paras) sel` when text is highlighted) · total word count · total character count · total paragraph count · Ln/Col · UTF-8 encoding · LF/CRLF indicator · version link on the extreme right (opens the GitHub repo, and doubles as the auto-update status indicator - see §3.9)
   - Separators: Styled as 1px high-contrast lines using specific CSS `font-size: 0; color: transparent;` and `:not(.status-separator)` padding filters to avoid square blocks in WebView2
 - Custom modals (no native confirm dialogs):
   - **Unsaved Changes Dialog:** Unified `.modal-body` overlay containing the title, message paragraph, and buttons (Save / Don't Save / Cancel) with an even `20px` gap and `24px` padding. Dismissable via overlay-click and Escape key
@@ -146,7 +146,7 @@ Theme auto-detection: reads `window.matchMedia('(prefers-color-scheme: dark)')` 
 - Persisted: theme, fontSize, fontFamily, tabSize, wordWrap, lineNumbers, syncScroll, recentFiles, windowWidth, windowHeight, windowMaximized, splitRatio, showPageBreaks, sysTray, editorMonospace
 
 ### 3.8 Performance Budget
-| Metric | Budget | Measured (v1.9.0) |
+| Metric | Budget | Measured (v1.10.x) |
 |---|---|---|
 | JS bundle (gzip, total) | < 450 KB | ~400 KB |
 | CSS bundle (gzip) | < 30 KB | ~19 KB |
@@ -159,21 +159,41 @@ Theme auto-detection: reads `window.matchMedia('(prefers-color-scheme: dark)')` 
 | Save IPC round-trips | 1 | 1 (`writeTextFile`; watcher echo suppressed by frontend flag) |
 
 ### 3.9 Auto-Updater
-The app check signed updates on startup:
+The app runs one signed background update check on startup. **All status is surfaced through the existing version text in the bottom-right status bar - no banners, no modal pop-ups.** Implemented as a three-phase state machine in [src/platform/updater.js](src/platform/updater.js):
+
+- **idle** - the version text shows `v<version>` and links to the GitHub repo
+- **updating** - a newer release was found; the app downloads and installs it in the background. The text changes to **`Updating...`**, the link is removed, and clicks are disabled (`.update-in-progress`, `pointer-events: none`) so the user cannot accidentally open the browser mid-update. On Windows the NSIS installer runs in **`quiet`** mode (`plugins.updater.windows.installMode` in `tauri.conf.json`) - no Setup window, no progress wizard. This is compatible with the `currentUser` bundle install mode (no admin elevation needed)
+- **ready** - once the update is staged, the text becomes **`Restart App!`** in the theme accent colour (`.update-ready`) as a subtle call-to-action
+
+**Network & signing**
 - **One outbound request** to `https://github.com/prathamreet/featherMD/releases/latest/download/latest.json` on app boot
-- No analytics, no headers identifying the user beyond the standard HTTP User-Agent
-- All release artifacts are signed with **Ed25519**; the public key is embedded in the binary
-- The updater verifies the signature on `latest.json` **before** writing anything
-- A new version surfaces as a slide-in banner; the user explicitly clicks **Update Now** to download and install
-- On install, `tauri-plugin-process::relaunch()` swaps to the new binary
-- CSP in `tauri.conf.json` allows `connect-src` only for `github.com` / `objects.githubusercontent.com` / `*.github.com`
-- Update check failures fail silently (no error UI when offline)
+- All release artifacts are signed with **Ed25519**; the public key is embedded in the binary, and the updater verifies the signature **before** writing anything
+- No headers identifying the user beyond the standard HTTP User-Agent
+- Update-check and download failures fail silently. On download failure the version text, link, and styling revert to the original idle state, so the user never sees an error
+
+**Smart restart (clicking `Restart App!`)**
+- Runs the existing `confirmDiscardChanges()` guard ([src/core/file-io.js](src/core/file-io.js)). With a dirty buffer it shows the Save / Don't Save / Cancel dialog: Save or Don't Save proceeds to `relaunch()`, Cancel aborts and leaves the text as `Restart App!` for a later retry. A clean buffer relaunches immediately
+
+**Exit behaviour while an update is pending**
+- *Staged (ready):* closing needs no prompt - Tauri applies the staged update on the next launch
+- *Still downloading + system tray active:* closing just hides to the tray (no prompt); the download continues in the background
+- *Still downloading + full quit* (close with no tray, tray "Quit", or Ctrl+Q without a tray): `requestQuit()` shows an **"Update in Progress"** warning (**Close Anyway** / **Wait for Update**) before the unsaved-changes guard, so the user can avoid aborting the download
+
+User settings persist across the relaunch automatically - `saveConfig()` writes preferences to `config.json` in real time (see §3.7). The updater's CSP `connect-src` allowance is documented in §10.
 
 ### 3.10 Analytics
 The app triggers an anonymous ping analytics call when online, sending the version, platform, language, and screen resolution:
 - **One outbound request** to `https://feather-md-analytics-production.up.railway.app` on app boot
 - No user-identifying data is sent
 - Offline states fail silently without affecting user experience or boot speed
+
+### 3.11 Printing & PDF Export
+Printing (`Ctrl+P` or File → Print) funnels through a single wrapped `window.print()`, so every entry point gets identical treatment:
+- **Forced light theme:** the output always renders in the `snow` palette regardless of the active editor theme. `initPrintThemeOverride()` ([src/main.js](src/main.js)) swaps `data-theme="snow"` and re-renders Mermaid diagrams (whose colours are baked into the SVG) in the light variant before printing, then restores the user's theme afterward. The saved theme is never written to disk.
+- **Chrome stripping:** `@media print` rules hide the header bar, status bar, editor pane, divider, and modals, so only the rendered document prints.
+- **Multi-page flow:** viewport height/overflow pinning is released so content flows across pages instead of being clipped to a single screen height; Mermaid/math internal scroll caps are lifted so full diagrams print.
+- **Page breaks:** a `<pb>` tag forces a hard page break (`page-break-before: always`). The dashed `<pb>` marker's visibility in the preview is toggled via View → Show Page Breaks / `Alt+P`.
+- **Layout protection:** code blocks and tables word-wrap at the page edge; tables, `<pre>`, blockquotes, and images avoid being split across pages; headings avoid being orphaned at the bottom of a page.
 
 ---
 
@@ -223,7 +243,8 @@ featherMD/
 │   │   ├── themes.js                Theme application + prefers-color-scheme listener.
 │   │   ├── dialogs.js               Custom unsaved-changes modal + shortcuts help modal.
 │   │   ├── status-bar.js            Word count, cursor pos, file path, CRLF/LF.
-│   │   └── divider.js               Editor/preview split-pane drag handle.
+│   │   ├── divider.js               Editor/preview split-pane drag handle.
+│   │   └── fullscreen.js            F11 distraction-free preview (maximize-based).
 │   │
 │   ├── core/
 │   │   ├── config.js                Defaults + Tauri appConfigDir / localStorage persistence.
@@ -237,8 +258,11 @@ featherMD/
 │   │   └── utils.js                 escapeHtml (regex-based, no DOM allocations).
 │   │
 │   ├── platform/
-│   │   ├── window.js                Tauri window controls + size/maximized persistence.
-│   │   └── updater.js               Ed25519-verified auto-update banner.
+│   │   ├── window.js                Tauri window controls + size/maximized persistence,
+│   │   │                            hide-to-tray, tray-aware quit + mid-download guard.
+│   │   └── updater.js               Ed25519-verified background auto-update. Drives the
+│   │                                status-bar update phases (idle / updating / ready)
+│   │                                and the unsaved-changes-guarded relaunch.
 │   │
 │   └── styles/
 │       ├── base.css                 Layout, header, status bar, modals, ALL 10 THEMES.
@@ -250,9 +274,10 @@ featherMD/
 │   ├── src/
 │   │   ├── main.rs                  Tauri app entry (windows_subsystem guard).
 │   │   └── lib.rs                   IPC commands: get_initial_file, watch_file,
-│   │                                unwatch_file. notify::RecommendedWatcher with
-│   │                                50 ms event-burst debounce.
-│   │                                Setup memory trimming for WebView2 on hide-to-tray.
+│   │                                unwatch_file, tray_active, set_tray,
+│   │                                set_webview_memory. notify::RecommendedWatcher with
+│   │                                50 ms event-burst debounce. System-tray build +
+│   │                                live toggle. WebView2 working-set trim on hide-to-tray.
 │   ├── capabilities/
 │   │   └── default.json             Tauri 2 permission scopes for plugins.
 │   ├── icons/                       Platform icons (Windows .ico, Linux .png).
@@ -306,9 +331,9 @@ npm run lint            # ESLint
 npm run report          # build + lint + tests + bench + bundle sizes
 
 # Outputs:
-# Windows:  src-tauri/target/release/bundle/nsis/Feather MD_1.9.0_x64-setup.exe
-# Linux:    src-tauri/target/release/bundle/deb/Feather MD_1.9.0_amd64.deb
-#           src-tauri/target/release/bundle/appimage/Feather MD_1.9.0_amd64.AppImage
+# Windows:  src-tauri/target/release/bundle/nsis/Feather MD_1.10.1_x64-setup.exe
+# Linux:    src-tauri/target/release/bundle/deb/Feather MD_1.10.1_amd64.deb
+#           src-tauri/target/release/bundle/appimage/Feather MD_1.10.1_amd64.AppImage
 ```
 
 ---
@@ -332,10 +357,12 @@ On `DOMContentLoaded`:
 5. `applyPersistedConfig()` reconfigures CodeMirror compartments + reflects state in menus
 6. Wire Tauri listeners:
    - `get_initial_file` IPC → load CLI-passed file
-   - `tauri://close-requested` → unsaved-changes guard (hide to tray or quit)
+   - `open-file-from-args` event → open a file forwarded by a second (single-instance) launch
+   - `tauri://close-requested` → hide to tray when a tray exists, else `requestQuit()` (unsaved-changes guard + mid-download update guard)
+   - `tray-quit` event → `requestQuit()` (the only full-process-exit path)
    - `file-changed-on-disk` event → handle external edits, honour `isSaving` echo window
 7. `initWindowSize()` restores window dimensions and maximized state, persists future resizes (debounced 500 ms)
-8. `initUpdater()` checks for a signed release (silent on failure)
+8. `initUpdater()` runs the signed background update check; drives the status-bar update phases, silent on failure
 
 ### Subsystem map
 
@@ -346,16 +373,17 @@ On `DOMContentLoaded`:
 | Sync scroll | `src/core/sync.js` | Active-source tracking, ratio sync, feedback-loop guard |
 | File IO | `src/core/file-io.js` | open / save / save-as / new, recent files, unsaved guard, `isSaving` echo flag |
 | Config | `src/core/config.js` | Defaults + JSON persistence (Tauri / localStorage) |
-| Keyboard | `src/core/keyboard.js` | Global shortcuts (Ctrl+S/O/N/L/F/H/?, Alt+Z/S, etc.) |
+| Keyboard | `src/core/keyboard.js` | Global shortcuts (Ctrl+O/S/Shift+S/N/R/Shift+R/Q/P/`.`), Alt+Z/X/C/P toggles, Alt+T/F/D leader chords, Ctrl+scroll zoom |
 | Themes | `src/ui/themes.js` | Theme application, OS preference, persistence callback |
 | Toolbar | `src/ui/toolbar.js` | Hover-intent menus, recent files builder, menu state accessors |
 | Dialogs | `src/ui/dialogs.js` | Unsaved-changes modal, shortcuts help modal, recent files modal |
 | Status bar | `src/ui/status-bar.js` | Word count, cursor pos, file path, line ending, selections count |
 | Divider | `src/ui/divider.js` | Split-pane drag + double-click reset + persistence |
+| Fullscreen | `src/ui/fullscreen.js` | F11 distraction-free preview mode (maximize-based; Esc / F11 to exit) |
 | Window controls | `src/platform/window.js` | Minimize / maximize / close + size restore + resize-persist, hide to tray |
-| Updater | `src/platform/updater.js` | Update check, signature verification, install banner |
+| Updater | `src/platform/updater.js` | Background update check, signature verification, status-bar phases (idle / updating / ready), unsaved-changes-guarded relaunch |
 | State | `src/core/state.js` | HMR-resistant window-scoped flags |
-| Backend | `src-tauri/src/lib.rs` | `get_initial_file`, `watch_file`, `unwatch_file` IPC commands; notify-based watcher, WebView2 memory and tray control |
+| Backend | `src-tauri/src/lib.rs` | `get_initial_file`, `watch_file`, `unwatch_file`, `tray_active`, `set_tray`, `set_webview_memory` IPC commands; notify-based watcher, WebView2 memory and tray control |
 
 ---
 
@@ -414,17 +442,18 @@ On `DOMContentLoaded`:
 default-src 'self';
 style-src 'self' 'unsafe-inline';
 font-src 'self';
-img-src 'self' asset: https: data:;
-connect-src 'self' https://github.com https://objects.githubusercontent.com https://*.github.com https://feather-md-analytics-production.up.railway.app
+img-src 'self' asset: http://asset.localhost https: data:;
+connect-src 'self' https://github.com https://objects.githubusercontent.com https://release-assets.githubusercontent.com https://feather-md-analytics-production.up.railway.app
 ```
 
 ### Permission scopes (`src-tauri/capabilities/default.json`)
 Tauri 2 capabilities are explicitly enumerated:
-- `core:default`, `core:event:allow-listen`, `core:event:allow-emit`
-- `dialog:allow-open`, `dialog:allow-save`
-- `fs:allow-read-text-file`, `fs:allow-write-text-file`, `fs:allow-mkdir`, `fs:scope` (allow `**` for user-chosen files)
-- `core:window:allow-{minimize,maximize,unmaximize,close,destroy,is-maximized,set-size}`
-- `opener:default`, `updater:default`, `process:default`
+- `core:default`, `core:event:default`, `core:event:allow-listen`, `core:event:allow-emit`
+- `opener:default`
+- `dialog:default`, `dialog:allow-open`, `dialog:allow-save`
+- `fs:default`, `fs:allow-read-text-file`, `fs:allow-read-file`, `fs:allow-write-text-file`, `fs:allow-write-file`, `fs:allow-mkdir`, `fs:allow-exists`, `fs:scope` (allow `**` for user-chosen files)
+- `core:window:allow-{minimize,maximize,unmaximize,close,destroy,is-maximized,set-size,show,hide,set-focus}`
+- `updater:default`, `process:default`, `process:allow-exit`
 
 ### Sanitization
 - Every preview render is sanitized by **DOMPurify** with `USE_PROFILES: { html: true }` and an explicit `ADD_ATTR: ['target']` for routed external links
@@ -432,7 +461,7 @@ Tauri 2 capabilities are explicitly enumerated:
 
 ### Data egress
 - Outbound HTTP only for the signed update check (§3.9) and anonymous ping analytics (§3.10). No file content, file paths, or user data is ever sent over the network.
-- No analytics, no crash reporting, no telemetry SDKs.
+- No crash reporting, no telemetry SDKs; the analytics ping (§3.10) carries only version, platform, language, and screen resolution.
 
 ---
 
@@ -476,15 +505,15 @@ Tauri 2 capabilities are explicitly enumerated:
 - [x] RAM < 60 MB with a 10,000-word file open (~50 MB measured)
 - [x] CPU < 1% when idle - native event-driven watcher, no polling timers
 - [x] Save path does not pause/resume the watcher (single IPC, `isSaving` flag suppresses echo)
-- [x] No telemetry. Auto-update check is the sole outbound request, signed (Ed25519) and user-gated for install.
+- [x] No file content or paths leave the device. The only outbound requests are the signed (Ed25519), user-gated background update check and an anonymous analytics ping (version/platform/language/resolution).
 - [x] 200+ Vitest specs passing; CI runs the full report on every PR
 
 ---
 
 ## 13. Release & Versioning
 
-- Versions live in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and the status bar version link in `index.html`
-- `scripts/version-bump.js` (invoked by the `npm version` lifecycle) syncs all four
+- `package.json` is the source of truth for the version (set it via `npm version`, which also updates `package-lock.json`)
+- `scripts/version-bump.js` (invoked by the `npm version` lifecycle) reads `package.json` and syncs the version into: `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, the status-bar version link in `index.html`, and the landing page (`page/styles.css` `page-version`, `page/index.html`)
 - Release artifacts published via `.github/workflows/release.yml`:
   - `Feather.MD_<version>_x64-setup.exe` + `.sig`
   - `Feather.MD_<version>_amd64.deb`
@@ -494,4 +523,4 @@ Tauri 2 capabilities are explicitly enumerated:
 
 ---
 
-*End of PRD - Feather MD v1.9.0*
+*End of PRD - Feather MD v1.10.1*

--- a/artifacts/docs/release-logs.md
+++ b/artifacts/docs/release-logs.md
@@ -1,185 +1,346 @@
-2 days ago
-@github-actions github-actions
- v1.4.1
- 24e77d5
-Feather MD v1.4.1 Latest
+# Feather MD Release Logs
+
+## Feather MD v1.10.0
+This update introducing a streamlined, silent background application update experience and enhanced safety guards during app relaunch.
+
+### Summary:
+- Quiet Updates: The application now checks for, downloads, and prepares updates silently in the background, removing the top banner pop-ups.
+- Status Indicators: You can track the update status directly in the bottom-right corner of the window. The version number will change to "Updating..." during download, and "Restart App!" when ready.
+- Smart Relaunch: Clicking "Restart App!" will restart the application to apply the update. If you have unsaved documents open, you will be prompted to save your work before the restart proceeds.
+- Exit Safeguard: If you attempt to quit the application while an update is actively downloading in the background, the app will warn you to prevent the download from being aborted.
+
+### Details:
+- State Machine Integration: Implemented a new updater state module (src/platform/updater.js) utilizing three states: idle (opens repository homepage), updating (disables interactions, changes styles), and ready (invokes relaunch after file guard check).
+- Graceful Failure Fallbacks: Implemented error boundaries during update check and download phases. If downloading fails, the version element silently reverts back to the original version and link behavior.
+- Clean Event Listener Replacement: Employed cloneNode(true) and replaceWith on the version element to swap click handlers from default URL opening to update relaunch sequence.
+- Centralized Exit Guard: Extended requestQuit() in src/platform/window.js (a unified entry point for close-to-tray, tray-quit, and keyboard shortcuts) to run a synchronous status check isUpdateInProgress() and prompt utilizing @tauri-apps/plugin-dialog if true.
+- Style Optimization: Cleaned up unused banner-related rules in src/styles/base.css and added .update-in-progress (deactivated events, opacity) and .update-ready (accent color, font weight) classes.
+
+---
+
+## Feather MD v1.9.2
+This is a minor UI quality-of-life update that resolves usability issues in split-pane mode.
+
+### Summary:
+- Slimmed down the visible drag bar between the editor and preview screens.
+- Fixed a layout bug where the invisible grab region of the separator would overlap the editor scrollbar, preventing clicks and scroll interactions near the right edge of the editor.
+
+### Details:
+- Modified base.css#L585-L621 to adjust #divider dimensions from width: 9px / margin: 0 -4px to width: 3px / margin: 0 -1px.
+- Offset the #divider::before active line position (left: 1px default, left: 0.5px dragging) for centered alignment.
+- Relocated the #divider::after interactive area to left: 0px and right: -9px to clear the editor's scroll footprint.
+
+---
+
+## Feather MD v1.9.1
+This is a minor update focusing on UI/UX modernization, space-based indentation, and interface cleanups.
+
+### Summary:
+- Space-based Indentation: Pressing Tab now inserts spaces instead of literal tab characters to preserve formatting across text editors.
+- Segmented Tab Sizes: Quick-select indentation from 1 to 6 spaces using a new horizontal button bar under the Style menu.
+- Editor Monospace Toggle: Easily switch the editor font stack between monospace and reading fonts via Style -> Font.
+- Clutter-Free Layout: Removed the header logo and relocated the clickable app version badge to the status bar footer.
+- Unified Dialogs: Refined padding, margins, and button positioning on the shortcuts, recent files, and unsaved changes dialogs.
+
+### Details:
+- CodeMirror Keymap: Replaced standard indentWithTab with a custom Tab handler supporting selection indenting and space padding.
+- Config Schema: Added editorMonospace default state and expanded standard tabSize validation limits to integers [1, 6].
+- Dynamic Styling: Wired the monospace menu toggle inside src/ui/toolbar.js to dynamically re-evaluate the --font-editor custom property.
+- DOM Refactoring: Deleted visible modal headers and added hidden close buttons for testing/accessibility. Simplified the unsaved changes dialog under a single body block.
+- Egress & version-bump: Re-routed the backend analytics ping to #status-version and updated the version-bump.js regex to target anchor patterns.
+- PRD & Tests: Updated ID assertions in tests/html.test.js and aligned specification assets in PRD.md and README.md to v1.9.1.
+
+---
+
+## Feather MD v1.9.0
+This is a minor release focusing on native OS integration, major memory reduction, and print pipeline reliability.
+
+### Summary:
+- System Tray Support: On Windows, closing the window now keeps Feather MD running in the background. This ensures you do not lose background tasks.
+- Lower Memory Footprint: By loading heavy math/diagram libraries on-demand, disabling unused GPU browser processes, and trimming memory pages when minimized, the app baseline RAM is significantly reduced.
+- Reliable PDF Exports: Closing the app immediately after printing will no longer result in broken, 0-byte PDF files. The application now prompts you and waits for the PDF compilation to complete.
+- Open Files in Existing Window: Launching another file while the app is already open will now open it directly inside the running window instead of launching a duplicate process.
+- Live Updater Progress: The auto-updater window now displays a live downloading percentage showing the real progress of the download.
+- Flexible Recent Files list: You can now remove individual items from your recent files list or clear the entire history.
+
+### Details:
+- System Tray Orchestration: Built native support in lib.rs using Tauri TrayIconBuilder and wired live menu updates, window hide/show behaviors, and context actions. Synchronized state checking in window.js via isTrayActive so the frontend fails safe to standard exit on platforms without tray support.
+- Working Set Trimming: Implemented COM interface query in Rust to access ICoreWebView2_19::SetMemoryUsageTargetLevel and set the target level to low when hiding the window.
+- Resource Reductions: Excluded GPU rendering and auxiliary browser features (such as msWebOOUI, msPdfOOUI, and msSmartScreenProtection) from tauri.conf.json. Configured opt-level "s", Link-Time Optimization (LTO), single-codegen-unit builds, and aborted panics in release profiles inside Cargo.toml.
+- On-Demand Math and Diagram Rendering: Extracted math and diagram examples from welcome.js and split them into a separate template loaded only on user request, avoiding cold-start import overhead.
+- Compiling PDF Overlay: Integrated a custom print-status checking loop inside main.js using the window.__FEATHER_PRINTING__ flag. Intercepted close requests to display a #print-overlay spinner in index.html, delaying the window teardown until compile time completes.
+- Asset Protocol Relocation: Configured local image path rewriting in preview.js to route absolute, relative, and file:// paths through Tauri's convertFileSrc helper.
+- Single-Instance Locks: Enforced a single application instance check via tauri-plugin-single-instance. Wired launch arguments to be captured and sent to the active window via the open-file-from-args event.
+- Editor Transaction Identification: Replaced global boolean flags with compartment-level transaction annotations using CodeMirror 6 to distinguish programmatic content updates from user edits inside editor.js.
+- Test Alignment: Updated Vitest test files html.test.js, performance.bench.js, and toolbar.test.js to support the new menu entries, correct font classes, and execute authentic regex stripping benchmarks.
+
+---
+
+## Feather MD v1.8.0
+This is a minor feature update adding advanced document extensions (math rendering and interactive diagrams) alongside user interface polishing and keyboard layout adjustments.
+
+### Summary:
+- Math Support: You can now write inline math (using $E = mc^2$) and block math (using $$...$$) directly in your markdown documents, which render smoothly in the preview pane.
+- Mermaid Diagrams: Fenced code blocks tagged with mermaid or mmd (e.g., Gantt charts, flowcharts, Git graphs) will now automatically render as rich, interactive diagrams.
+- Improved Printing: Printed outputs and PDF exports will now always use the clean, highly-readable "snow" (light) theme, ensuring diagrams and text remain perfectly legible regardless of your active editor theme.
+- Tuned Keyboard Controls: The leader-key system (used for Alt + T/F/D cycling) now disarms much faster (in 800 milliseconds instead of 2 seconds) once you finish cycling, meaning arrow keys return to normal text navigation almost immediately.
+- Reorganized Shortcuts Dialog: The shortcuts dialog is now grouped by category (File, View, Style, Editor, App), supports Escape key dismissal, and can be toggled using the Ctrl + . shortcut.
+- Updated Scratchpad: The welcome text has been refreshed with direct examples of KaTeX equations, Mermaid diagrams, and updated instructions.
+
+### Technical Details:
+- Dynamic Imports & Code-Splitting: Dynamic dynamic-imports are used to lazy-load the heavy katex and mermaid libraries only when the parser detects math delimiters or diagram code blocks. Highlighting modules are also fetched via Vite's import.meta.glob on-demand to keep initial startup memory under 30 MB.
+- Marked Extensions: Custom tokenizers parse blockMath and inlineMath before syntax highlighting or general markdown generation, parking raw TeX inside custom data-tex attributes so that it survives DOMPurify HTML sanitization.
+- LRU Caching: Bounded LRU caches (mathCache size 256, mermaidCache size 64) store rendered SVG/HTML output. This ensures active typing in the editor pane does not trigger redundant compilation passes for unmodified blocks.
+- Theme Parity for SVG Diagrams: Mermaid initializes dynamically with the correct light or dark variant. Theme shifts trigger refreshForThemeChange(), which re-renders SVG nodes in-place without restarting the entire markdown compiler. Height pinning prevents layout layout-shifts and viewport scrolling jumps during async re-renders.
+- Print Override: Intercepts window.print() to switch the top-level HTML data-theme attribute to snow and awaits Mermaid theme refresh before letting the browser print the layout. Restores the user's active theme in an afterprint listener.
+- Keyboard Chord Tuning: Modified armLeader inside src/core/keyboard.js to accept a custom timeout duration, updating the post-cycle re-arm to use LEADER_CYCLE_REARM_MS (800 ms) while leaving the initial chord window at LEADER_WINDOW_MS (2000 ms).
+- Test Coverage: Added tests/preview/math-mermaid.test.js written in Vitest to run tokenization checks, false-positive currency guards, invalid math error boundaries, and integration sanitization checks under jsdom.
+
+---
+
+## Feather MD v1.7.0
+This is a minor update focusing on keyboard efficiency, distraction-free editing, and user settings accessibility.
+
+### Summary:
+- Distraction-Free Fullscreen Preview: Press F11 to hide the editor, status bar, and toolbar, displaying only your rendered document in fullscreen. Press Esc or F11 to return.
+- Quick Style Cycling: Tap Alt + T (themes), Alt + F (fonts), or Alt + D (tab sizes) followed by ↑/↓ arrow keys to quickly customize the editor interface without using the mouse.
+- Recent Files Dialog: Access your recently opened documents in a clean, scrollable window using Ctrl + R.
+- Keyboard Controls: Quit the app with Ctrl + Q and reload/refresh the app cleanly with Ctrl + Shift + R.
+- Remapped Shortcuts: Adjustments made to word wrap, sync scroll (Alt + X), and line numbers (Alt + C) to prevent keyboard conflicts.
+
+### Technical Details:
+- Capture-Phase Leader Sequence: Integrated a capture-phase keydown event listener in keyboard.js to intercept up/down arrow inputs after Alt-chords. This manages a 2-second timeout window to prevent standard CodeMirror inputs during configuration cycling.
+- Tauri Window Optimization: Modified window.js to utilize Tauri's isMaximized, maximize, and unmaximize APIs. This avoids OS-level borderless fullscreen layout glitches in Windows where the WebView lag leaves unpainted areas.
+- DOM & CSS Refactoring: Repositioned the split container to fixed viewport coordinates (inset: 0) and applied theme-based background paint during fullscreen mode. Replaced submenu elements in index.html and base.css with a modal layout (#recent-files-modal and #recent-files-list).
+- Safety reload: Implemented a reload utility that prompts the user through confirmDiscardChanges() in file-io.js to protect modifications before refreshing.
+- Test Suite Enhancements: Added comprehensive vitest suites: fullscreen.test.js validating JSDOM classes and hint timeouts; themes.test.js validating cyclical array traversals; and updated toolbar element assertions in toolbar.test.js and html.test.js.
+
+---
+
+## Feather MD v1.6.1
+Internal maintenance and security alignment update.
+
+Minor internal configuration and connection profiles updated.
+No new features, interface modifications, or behavioral changes from v1.6.0.
+
+---
+
+## Feather MD v1.6.0
+
+### New Features:
+- Page Breaks Support (<pb>): You can now structure your PDF export layouts by inserting <pb> page break tags.
+- Page Break Visibility Toggle: Toggle the visibility of the visual dashed line for <pb> markers in the preview pane via the View > Show Page Breaks menu or using the new shortcut Alt + P.
+- Rich Document Statistics: The status bar now displays individual counts for Words, Characters, and Paragraphs instead of just words.
+- Accurate Statistics Counting: Markdown formatting characters (such as links, code block fences, tables, checklists) are now stripped out of raw text before counting for higher statistical accuracy.
+- Selection Stats: Highlight any text in the editor to immediately see the selected word, character, and paragraph count in the status bar.
+- Distraction-Free Printing: Headings are prevented from being orphaned at the bottom of pages, and tables, code blocks, or blockquotes will avoid page splits when printing or exporting to PDF.
+
+### Improvements & Usability:
+- Window Dragging: The application window can now be dragged by clicking and dragging the main title bar, with button and menu interactions protected from accidental drag events.
+
+### Bug Fixes & Chores:
+- Resolved a linter error related to an unused catch variable.
+- Fixed backtick rendering and escaped tags within the Welcome document.
+- Updated UI unit tests to align with status bar elements and view items.
+
+---
+
+## Feather MD v1.5.1
+FeatherMD v1.5.1 introduces UI interaction refinements, typography zoom synchronization, editor-preview syntax highlighting alignment, and development build optimizations.
+
+### User Interface and Experience Upgrades:
+- Clean Brand Vector Logo: Replaced the distorted top-left feather icon with a clean, minimalist SVG path.
+- Interactive Hover Logo: Removed button-like hover highlights (scale, backgrounds, borders). Implemented a smooth CSS cross-fade transition that replaces the logo with the version number inline on hover.
+- Tauri Desktop Opener Integration: Configured the top-left icon to open the GitHub repository (https://github.com/prathamreet/featherMD) using Tauri's opener plugin in desktop mode with browser fallback.
+- Line Numbers Zoom Sync: Linked CodeMirror's layout remeasurement to Ctrl + Scroll zoom events, badge reset clicks, and toolbar styling selections, resolving a bug where line numbers went out of alignment when zooming.
+
+### Editor and Syntax Refactoring:
+- Highlight.js Theme Alignment: Harmonized CodeMirror tokens (headings, keywords, strings, names, comments) styling variables to match Highlight.js preview layouts.
+- Preview Inline Snippets: Styled inline code snippets in the preview pane to align with CodeMirror editors.
+- Zero-Flash Lazy Language Loader: Refactored language styling checks to run synchronously when language modules are cached, resolving a brief unstyled text flash on preview changes.
+- Preview Diff Classes: Added background styling for Git addition (.hljs-addition) and deletion (.hljs-deletion) inside code blocks.
+
+### Build and Tooling Upgrades:
+- Vite HMR Optimization: Added the Rust compile target folder to Vite's file watcher ignore list to eliminate recursive hot-reloading loops during development.
+- Workspace Clean Scripts: Added new rm-dist, rm-target, and rm-nm script utilities in package.json for cleaner dev environment resets.
+- Version Bump Automation: Updated scripts/version-bump.js and npm version git-add hooks to dynamically synchronize the version string inside index.html on new releases.
+
+---
+
+## Feather MD v1.5.0
+FeatherMD v1.5.0 introduces interaction design modernizations, native desktop capability improvements, and backend resource optimizations.
+
+### Performance and Engine Refactoring:
+- Event-Driven File Watcher: Replaced the async Tokio-based file watcher with the event-driven notify crate, reducing idle background CPU usage to 0%.
+- Write Echo Suppression: Implemented a frontend isSaving flag to prevent redundant triple-IPC loops during file writes.
+- HTML Escaping Optimization: Refactored the preview renderer to use regex-based HTML escaping, eliminating intermediate DOM allocations.
+- CodeMirror Consolidation: Merged redundant EditorView.updateListener registrations and removed unnecessary requestAnimationFrame wrappers in change handlers.
+- Theme Consolidated Stylesheet: Combined all ten distinct theme configuration files into CSS custom properties inside a single base.css file.
+
+### User Interface and Experience Upgrades:
+- Integrated Zoom Interaction:
+  - Removed the legacy header font-size slider.
+  - Implemented global Ctrl + Scroll zooming (from 8px to 36px font range).
+  - Scaled CodeMirror line numbers gutter size to 0.85em to keep gutter size in sync with text zoom.
+  - Added a standalone zoom percentage badge in the header that displays a "Reset" indicator on hover and resets the zoom level to 100% on click.
+- Custom Unsaved Changes Modal: Replaced native browser dialogs with a custom confirmation modal supporting Esc to cancel, single-key shortcuts (S, N, C), keyboard hints, and capture-phase event listeners.
+- Dropdown Menu Persistence: Modified Font, Theme, and Tab menus to stay open on clicks for faster selection, closing on mouse leave after a 180ms grace delay.
+- Native Titlebar and Bounds: Added rectangular window controls and configured the window to launch hidden, revealing it only after window bounds are loaded and applied to prevent startup flicker.
+
+### Bug Fixes:
+- Startup Visibility: Added missing allow-show, allow-hide, and allow-set-focus capabilities permissions to resolve a launch bug where the window would flash and close.
+- Window Controls Initialization: Moved titlebar button bindings to Phase 2 of the bootstrap pipeline after Tauri is initialized, resolving an issue where the minimize, maximize, and close buttons were inert.
+
+### Documentation:
+- PRD Update: Updated the Product Requirement Document to reflect the new modular architecture, revised performance budgets, and auto-updater configurations.
+- README Cleanup: Updated the architecture map and purged obsolete local screenshot assets.
+
+---
+
+## Feather MD v1.4.1
 Internal release synchronization. No new features, no behavior changes.
 This release is purely a developer-experience correction and an auto-update pipeline synchronization. The app looks and behaves exactly like v1.4.0. If you are already on v1.4.0 and everything works fine, you do not need this release. Auto-update will sync this version.
 
-What changed under the hood
-Version Sync Automation: Added scripts to version-bump.js to automatically sync the brand icon's hover version tooltip with package.json on all future releases.
-Header Brand Tooltip: Restored the brand icon hover tooltip to match the active release version instead of the legacy fallback.
-Auto-Commit Tracking: Included the src/styles/base.css stylesheet in the automated npm version lifecycle hooks to ensure all bundle versions are kept in perfect alignment.
-Full Changelog: v1.4.0...v1.4.1
+### What changed under the hood:
+- Version Sync Automation: Added scripts to version-bump.js to automatically sync the brand icon's hover version tooltip with package.json on all future releases.
+- Header Brand Tooltip: Restored the brand icon hover tooltip to match the active release version instead of the legacy fallback.
+- Auto-Commit Tracking: Included the src/styles/base.css stylesheet in the automated npm version lifecycle hooks to ensure all bundle versions are kept in perfect alignment.
+- Full Changelog: v1.4.0...v1.4.1
 
-Assets
-8
-Feather.MD_1.4.1_amd64.AppImage
-sha256:b0e887d77691644a46e59ef789ffc4dfb227f9a9f28e1ccac53729688c494c62
-81.4 MB
-2 days ago
-Feather.MD_1.4.1_amd64.AppImage.sig
-sha256:9c606eafa400c374f13dee8d0b5cfefe97350c11c44efb9209846816d3430dc2
-424 Bytes
-2 days ago
-Feather.MD_1.4.1_amd64.deb
-sha256:6ca5c3d717a79841b78fa6531a2b21e85e429953cc59509c4c29821904ade3a4
-7.8 MB
-2 days ago
-Feather.MD_1.4.1_x64-setup.exe
-sha256:f94a23f8edcbd34b8da27e5f54563a10c07195872ecc488cd7f363d082625adf
-5 MB
-2 days ago
-Feather.MD_1.4.1_x64-setup.exe.sig
-sha256:a05b162da95f7a5c35c1ed976d5346429483df14e5df0d09a248c1bb351ff77e
-420 Bytes
-2 days ago
-latest.json
-sha256:8382db2138ffb355c71fc3f53bc4dcbc7301b9ff3fbd5300b51c783dc91f29ee
-1.3 KB
-2 days ago
-Source code
-(zip)
-2 days ago
-Source code
-(tar.gz)
-2 days ago
-Feather MD v1.4.0
-2 days ago
-@github-actions github-actions
- v1.4.0
- a6f9dc2
-Feather MD v1.4.0
+---
+
+## Feather MD v1.4.0
 Premium Combined Header, Hover-Intent Menus, and Advanced Printing
 This minor release delivers a complete user experience overhaul and core optimization:
 
-Unified Header Bar
-Combined the legacy title-bar and toolbar into a singular, 40px Unified Header Bar.
-Mathematically centered the active document title horizontally with transparent pointer events.
-Purged the heavyweight settings panel side-drawer, consolidating controls into lightweight dropdowns.
-Hover Dropdown Menus
-Enabled mouse hover-activation for all dropdown panels.
-Integrated a 180ms hover-intent delay to prevent accidental menu dismissal.
-Added a diagonal pointer bridge to eliminate cursor drift cutoffs.
-Grouped Theme (locked to :root to preserve text contrast), Font, and Tab Size options under nested Style submenus.
-Added a custom brand icon featuring a version-check v1.4.0 hover tooltip.
-Core & Platform Upgrades
-Completely removed legacy Vim Mode configurations and packages.
-Added windowMaximized state persistence to save and restore window dimensions on startup.
-Fully refactored all 204 unit tests to achieve 100% test coverage for the new header structure.
-Advanced Printing Engine
-Bypassed browser native headers and footers (hostnames, local times, page URLs) using page margin bypasses.
-Solved 100vh viewport-clipping issues to support infinite multi-page document prints.
-Recent Files Bugfix
-Fixed a file-saving bug so newly saved files register and update the File -> Recent Files list immediately.
-Full Changelog: v1.3.5...v1.4.0
+### Unified Header Bar:
+- Combined the legacy title-bar and toolbar into a singular, 40px Unified Header Bar.
+- Mathematically centered the active document title horizontally with transparent pointer events.
+- Purged the heavyweight settings panel side-drawer, consolidating controls into lightweight dropdowns.
 
-Assets
-8
-Feather MD v1.3.5
-3 days ago
-@github-actions github-actions
- v1.3.5
- 6e84fc9
-Feather MD v1.3.5
+### Hover Dropdown Menus:
+- Enabled mouse hover-activation for all dropdown panels.
+- Integrated a 180ms hover-intent delay to prevent accidental menu dismissal.
+- Added a diagonal pointer bridge to eliminate cursor drift cutoffs.
+- Grouped Theme (locked to :root to preserve text contrast), Font, and Tab Size options under nested Style submenus.
+- Added a custom brand icon featuring a version-check v1.4.0 hover tooltip.
+
+### Core & Platform Upgrades:
+- Completely removed legacy Vim Mode configurations and packages.
+- Added windowMaximized state persistence to save and restore window dimensions on startup.
+- Fully refactored all 204 unit tests to achieve 100% test coverage for the new header structure.
+
+### Advanced Printing Engine:
+- Bypassed browser native headers and footers (hostnames, local times, page URLs) using page margin bypasses.
+- Solved 100vh viewport-clipping issues to support infinite multi-page document prints.
+
+### Recent Files Bugfix:
+- Fixed a file-saving bug so newly saved files register and update the File -> Recent Files list immediately.
+- Full Changelog: v1.3.5...v1.4.0
+
+---
+
+## Feather MD v1.3.5
 Internal refactor. No new features, no fixes, no behavior changes.
 This release is purely a codebase reorganization and an auto-update pipeline verification. The app looks, feels, and runs identically to v1.3.4. If you are on v1.3.4 and everything works fine, you do not need this release. Auto-update will pick it up on next launch.
 
-What changed under the hood
-src/ regrouped into editor/, preview/, ui/, core/, and platform/ subfolders.
-main.js split from 915 lines into a 314-line orchestrator plus nine focused modules.
-tests/ mirrors the new src/ layout. 221/221 specs still pass.
-README rewritten with detailed architecture, performance budget, and comparison table.
-Issue and PR templates refreshed.
-Full changelog: v1.3.4...v1.3.5
+### What changed under the hood:
+- src/ regrouped into editor/, preview/, ui/, core/, and platform/ subfolders.
+- main.js split from 915 lines into a 314-line orchestrator plus nine focused modules.
+- tests/ mirrors the new src/ layout. 221/221 specs still pass.
+- README rewritten with detailed architecture, performance budget, and comparison table.
+- Issue and PR templates refreshed.
+- Full changelog: v1.3.4...v1.3.5
 
-Assets
-8
-Feather MD v1.3.4
-4 days ago
-@github-actions github-actions
- v1.3.4
- 6adf958
-Feather MD v1.3.4
+---
+
+## Feather MD v1.3.4
 Feather MD v1.3.4 delivers critical bug fixes, editor usability enhancements, native platform improvements, and a major bundle size optimization.
 
-Key Enhancements
-Optimized Preview Bundle: Switched markdown code-block syntax coloring to lazy load components dynamically as needed. This significantly reduces the initial bundle footprint and compilation size.
-Tab Key Space Insertion: Configured CodeMirror state to ensure pressing the Tab key inserts physical spaces matching your tab-size preference rather than just changing the display width.
-Startup Preferences Restoration: Seamlessly restores your customized configuration (line numbers, word wrapping, Vim mode, scroll-sync, and editor split ratio) on application startup.
-External Link Browser Routing: HTTP/HTTPS external links now open directly in your host operating system's default browser instead of navigating inside the webview window.
-Smart File-Watcher: Silently reloads unmodified active files when changed on disk by external programs, prompting you only when the editor buffer has unsaved changes.
-Window Boundary Persistence: Restores your custom window size on launch, utilizing debounced event tracking to persist adjustments.
-Bug Fixes
-Resolved a toolbar binding issue that caused the settings panel to instantly close when clicking the settings button.
-Fixed an initialization race condition where file-opened IPC listeners were registered before DOM content finished mounting.
-Cleaned up unbundled font family fallbacks from the settings dropdown.
-Refactored native Tauri capability permissions, removing unused dialog handles.
-Assets
-8
-Feather MD v1.3.3
-4 days ago
-@github-actions github-actions
- v1.3.3
- d3ec9ae
-Feather MD v1.3.3
+### Key Enhancements:
+- Optimized Preview Bundle: Switched markdown code-block syntax coloring to lazy load components dynamically as needed. This significantly reduces the initial bundle footprint and compilation size.
+- Tab Key Space Insertion: Configured CodeMirror state to ensure pressing the Tab key inserts physical spaces matching your tab-size preference rather than just changing the display width.
+- Startup Preferences Restoration: Seamlessly restores your customized configuration (line numbers, word wrapping, Vim mode, scroll-sync, and editor split ratio) on application startup.
+- External Link Browser Routing: HTTP/HTTPS external links now open directly in your host operating system's default browser instead of navigating inside the webview window.
+- Smart File-Watcher: Silently reloads unmodified active files when changed on disk by external programs, prompting you only when the editor buffer has unsaved changes.
+- Window Boundary Persistence: Restores your custom window size on launch, utilizing debounced event tracking to persist adjustments.
+
+### Bug Fixes:
+- Resolved a toolbar binding issue that caused the settings panel to instantly close when clicking the settings button.
+- Fixed an initialization race condition where file-opened IPC listeners were registered before DOM content finished mounting.
+- Cleaned up unbundled font family fallbacks from the settings dropdown.
+- Refactored native Tauri capability permissions, removing unused dialog handles.
+
+---
+
+## Feather MD v1.3.3
 Bug Fixes and Boilerplate Cleanup
 
-Suspended the file watcher temporarily during save events to eliminate false "File Modified Externally" reload prompts.
-Replaced the application-specific welcome boilerplate with a generic Markdown writing sandbox.
-Assets
-8
-Feather MD v1.3.2
-4 days ago
-@github-actions github-actions
- v1.3.2
- a6918a0
-Feather MD v1.3.2
+- Suspended the file watcher temporarily during save events to eliminate false "File Modified Externally" reload prompts.
+- Replaced the application-specific welcome boilerplate with a generic Markdown writing sandbox.
+
+---
+
+## Feather MD v1.3.2
 Feather MD version 1.3.2 introduces critical performance optimizations, core compilation bug fixes, and a comprehensive cleanup of dead code.
 
-Performance Optimizations
+### Performance Optimizations:
+- Implemented Frame-Throttled Rendering using requestAnimationFrame. Typing within the editor is now completely lag-free, while the preview pane updates in lockstep with the monitor's paint refresh cycles.
 
-Implemented Frame-Throttled Rendering using requestAnimationFrame. Typing within the editor is now completely lag-free, while the preview pane updates in lockstep with the monitor's paint refresh cycles.
-Bug Fixes
+### Bug Fixes:
+- Resolved a compilation failure in the asynchronous file watcher thread by adding the tokio dependency to Cargo.toml and standardizing sleep durations.
 
-Resolved a compilation failure in the asynchronous file watcher thread by adding the tokio dependency to Cargo.toml and standardizing sleep durations.
-Cleanups and Refactorings
+### Cleanups and Refactorings:
+- Purged the unused active_path managed state field and related lock mutations from the FileWatcher Rust struct.
+- Eliminated five unused helper function exports (isSettingsOpen, isSyncEnabled, getCurrentTheme, getThemes, and getView) from the frontend modules.
 
-Purged the unused active_path managed state field and related lock mutations from the FileWatcher Rust struct.
-Eliminated five unused helper function exports (isSettingsOpen, isSyncEnabled, getCurrentTheme, getThemes, and getView) from the frontend modules.
-Assets
-8
-Feather MD v1.3.1
-4 days ago
-@github-actions github-actions
- v1.3.1
- 39c8088
-Feather MD v1.3.1
+---
+
+## Feather MD v1.3.1
 This is a visual test release to verify and demonstrate the functionality of the newly integrated Over-the-Air (OTA) automatic updater system.
 
-What's Changed
-Startup Welcome Boilerplate: Updated the default startup markdown document to explicitly celebrate the successful delivery of the v1.3.1 release.
-Auto-Updater Validation: Verified signature handshakes and OTA patch distribution pipelines.
-Installation
-Existing v1.3.0 users will receive this update automatically inside the application!
-New users can download the standard installers listed below.
-Assets
-8
-Feather MD v1.3.0
-4 days ago
-@github-actions github-actions
- v1.3.0
- 83262c9
-Feather MD v1.3.0
+### What's Changed:
+- Startup Welcome Boilerplate: Updated the default startup markdown document to explicitly celebrate the successful delivery of the v1.3.1 release.
+- Auto-Updater Validation: Verified signature handshakes and OTA patch distribution pipelines.
+
+### Installation:
+- Existing v1.3.0 users will receive this update automatically inside the application!
+- New users can download the standard installers listed below.
+
+---
+
+## Feather MD v1.3.0
 This release introduces native, cryptographically secure Over-The-Air (OTA) automatic updates alongside under-the-hood optimization tweaks.
 
-What's New
-Automatic Software Updates: The app will now silently check for new versions on startup. When a new release is published, a sleek, minimalist slide-in banner will notify you.
-One-Click Installation: Download, verify signatures, install, and relaunch seamlessly with a single click.
-Cryptographic Signatures: All release packages are signed with Ed25519 signatures, ensuring your updates are verified and authentic.
-Code Quality & Cleanliness: Underwent extensive performance benchmarking.
-Installation
-Windows: Download and run Feather.MD_1.3.0_x64-setup.exe below.
-Linux: Download the .deb or portable .AppImage packages.
-Assets
-8
+### What's New:
+- Automatic Software Updates: The app will now silently check for new versions on startup. When a new release is published, a sleek, minimalist slide-in banner will notify you.
+- One-Click Installation: Download, verify signatures, install, and relaunch seamlessly with a single click.
+- Cryptographic Signatures: All release packages are signed with Ed25519 signatures, ensuring your updates are verified and authentic.
+- Code Quality & Cleanliness: Underwent extensive performance benchmarking.
+
+### Installation:
+- Windows: Download and run Feather.MD_1.3.0_x64-setup.exe below.
+- Linux: Download the .deb or portable .AppImage packages.
+
+---
+
+## Feather MD v1.2.7
+Release Notes
+
+- Streamlined and optimized the CI/CD build pipeline.
+- Focused release targets exclusively on Windows (.exe) and Linux (.deb) platforms.
+- Configured Windows installer setup options to improve the default installation flow.
+- General workflow and build stability improvements.
+
+---
+
+## Feather MD v1.0.1
+
+### Bug Fixes & Stability:
+- Fixed Unsaved Changes Guard: Resolved a critical bug in Tauri's native dialog message handler where state changes were ignored, causing all prompt actions (Save, Don't Save, Cancel) to discard changes or freeze.
+- Custom Prompts: Replaced native message boxes with a custom visual Promise-based overlay for robust handling of unsaved modifications on New File, Open File, and App Close events.
+- Save Dialog Fix: Restored standard native file picker behavior when prompting to save changes on new or unnamed files.
+
+### Enhancements:
+- Complete Performance Readme: Redesigned project documentation aligning strictly to Feather MD performance budgets (under 100ms cold start, under 10MB installer, under 60MB RAM footprint).
+- Improved Focus States: Keyboard focus is automatically mapped to default action buttons when confirmation dialogs appear.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -68,6 +68,9 @@
   },
   "plugins": {
     "updater": {
+      "windows": {
+        "installMode": "quiet"
+      },
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFFRTIyOTRBRjBBNTVBODkKUldTSldxWHdTaW5pSG5vS0J5b0JLcmtQaHRMNE1xUW5xSUpjZS85b2dubnozaFNkMmtVeUFaWjUK",
       "endpoints": [
         "https://github.com/prathamreet/featherMD/releases/latest/download/latest.json"


### PR DESCRIPTION
## Summary

Sets the Windows updater plugin `installMode` to `quiet` in `tauri.conf.json` to enable fully silent background update installation without user-facing wizard prompts on Windows. Also updates the project's documentation (`README.md` and `PRD.md`) to reflect the background auto-update behavior, remapped shortcuts, capabilities, and system tray integration, alongside formatting historical logs in `release-logs.md`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Breaking change
- [x] Documentation only
- [x] Build, CI, or tooling
