### PR TITLE
fix(updater): defer update installation to restart click

### DIFF
--- a/artifacts/docs/PRD.md
+++ b/artifacts/docs/PRD.md
@@ -162,7 +162,7 @@ Theme auto-detection: reads `window.matchMedia('(prefers-color-scheme: dark)')` 
 The app runs one signed background update check on startup. **All status is surfaced through the existing version text in the bottom-right status bar - no banners, no modal pop-ups.** Implemented as a three-phase state machine in [src/platform/updater.js](src/platform/updater.js):
 
 - **idle** - the version text shows `v<version>` and links to the GitHub repo
-- **updating** - a newer release was found; the app downloads and installs it in the background. The text changes to **`Updating...`**, the link is removed, and clicks are disabled (`.update-in-progress`, `pointer-events: none`) so the user cannot accidentally open the browser mid-update. On Windows the NSIS installer runs in **`quiet`** mode (`plugins.updater.windows.installMode` in `tauri.conf.json`) - no Setup window, no progress wizard. This is compatible with the `currentUser` bundle install mode (no admin elevation needed)
+- **updating** - a newer release was found; the app **downloads** it in the background. The text changes to **`Updating...`**, the link is removed, and clicks are disabled (`.update-in-progress`, `pointer-events: none`) so the user cannot accidentally open the browser mid-update. The update is downloaded but **deliberately not installed yet** - on Windows the NSIS install step closes and restarts the app, so installing is deferred to the user's restart click (see *ready*). Implemented with `update.download()`, **not** `downloadAndInstall()`
 - **ready** - once the update is staged, the text becomes **`Restart App!`** in the theme accent colour (`.update-ready`) as a subtle call-to-action
 
 **Network & signing**
@@ -172,10 +172,11 @@ The app runs one signed background update check on startup. **All status is surf
 - Update-check and download failures fail silently. On download failure the version text, link, and styling revert to the original idle state, so the user never sees an error
 
 **Smart restart (clicking `Restart App!`)**
-- Runs the existing `confirmDiscardChanges()` guard ([src/core/file-io.js](src/core/file-io.js)). With a dirty buffer it shows the Save / Don't Save / Cancel dialog: Save or Don't Save proceeds to `relaunch()`, Cancel aborts and leaves the text as `Restart App!` for a later retry. A clean buffer relaunches immediately
+- Runs the existing `confirmDiscardChanges()` guard ([src/core/file-io.js](src/core/file-io.js)). With a dirty buffer it shows the Save / Don't Save / Cancel dialog: Save or Don't Save proceeds to **install the staged download (`update.install()`) and relaunch**, Cancel aborts and leaves the text as `Restart App!` for a later retry. A clean buffer installs + relaunches immediately
+- On Windows the install runs the NSIS installer in **`quiet`** mode (`plugins.updater.windows.installMode` in `tauri.conf.json`) - no Setup window, no progress wizard - which is compatible with the `currentUser` bundle install mode (no admin elevation needed)
 
 **Exit behaviour while an update is pending**
-- *Staged (ready):* closing needs no prompt - Tauri applies the staged update on the next launch
+- *Downloaded (ready):* closing needs no prompt. Because the install is deferred to the restart click, nothing is half-applied on disk - the update is simply re-downloaded on the next launch
 - *Still downloading + system tray active:* closing just hides to the tray (no prompt); the download continues in the background
 - *Still downloading + full quit* (close with no tray, tray "Quit", or Ctrl+Q without a tray): `requestQuit()` shows an **"Update in Progress"** warning (**Close Anyway** / **Wait for Update**) before the unsaved-changes guard, so the user can avoid aborting the download
 

--- a/src/platform/updater.js
+++ b/src/platform/updater.js
@@ -4,10 +4,14 @@
 // Background auto-update with status communicated through the existing version
 // text in the bottom-right status bar. Three phases:
 //
-//   idle      — version text shows "v1.9.2", clickable (opens GitHub repo).
-//   updating  — version text shows "Updating...", click disabled.
-//   ready     — version text shows "Restart App!", accent-colored, clickable
-//               (relaunches after unsaved-changes guard).
+//   idle      — version text shows "v1.10.x", clickable (opens GitHub repo).
+//   updating  — newer release found; the bytes DOWNLOAD in the background. Text
+//               shows "Updating...", click disabled. The update is downloaded but
+//               deliberately NOT installed yet — on Windows the NSIS install step
+//               closes/restarts the app, so installing is deferred to the user.
+//   ready     — download finished. Text shows "Restart App!", accent-colored,
+//               clickable. The click runs the unsaved-changes guard, then installs
+//               the staged update and relaunches — restart only with consent.
 
 import { confirmDiscardChanges } from '../core/file-io.js';
 
@@ -58,11 +62,15 @@ export async function initUpdater() {
     versionEl.classList.add('update-in-progress');
 
     try {
-      await update.downloadAndInstall();
+      // Download ONLY — do not install here. On Windows the NSIS install step
+      // closes and relaunches the app, which would restart the user without
+      // their consent. Installing is deferred to the "Restart App!" click so the
+      // restart is always explicit (see the ready phase below).
+      await update.download();
     } catch (err) {
       // Download failed — silently revert to original state. The user never
       // knew an update was happening, so no error UI is needed.
-      console.warn('[Updater] Download/install failed:', err);
+      console.warn('[Updater] Download failed:', err);
       _phase = 'idle';
       versionEl.textContent = originalText;
       if (originalHref) versionEl.setAttribute('href', originalHref);
@@ -87,9 +95,14 @@ export async function initUpdater() {
       e.preventDefault();
       if (!(await confirmDiscardChanges())) return;
       try {
+        // Install the already-downloaded update, THEN relaunch. On Windows the
+        // NSIS installer swaps the binary and restarts the app; relaunch() covers
+        // macOS/Linux where the restart must be requested explicitly. Either way
+        // this only runs after the user clicked "Restart App!".
+        await update.install();
         await relaunch();
       } catch (err) {
-        console.error('[Updater] Relaunch failed:', err);
+        console.error('[Updater] Install/relaunch failed:', err);
       }
     });
   } catch (err) {


### PR DESCRIPTION
## Summary

Decouples the download and install phases in the background updater. By using `update.download()` instead of `update.downloadAndInstall()`, the update is staged silently in the background without triggering an immediate, non-consensual application close. The actual installation (`update.install()`) is deferred until the user explicitly clicks the "Restart App!" button, preserving user work and preventing accidental data loss.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Breaking change
- [ ] Documentation only
- [ ] Build, CI, or tooling