### PR TITLE
fix(lint): ignore compiled page assets and clean up unused catch bindings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@ export default [
       'dist/**',
       'src-tauri/**',
       'target/**',
+      'page/demo/**',
     ],
   },
   js.configs.recommended,

--- a/page/script.js
+++ b/page/script.js
@@ -38,7 +38,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
     demoActivate.addEventListener( 'click', () => {
       demoFrame.style.pointerEvents = 'auto';
       demoActivate.style.display = 'none';
-      try { demoFrame.contentWindow.focus(); } catch ( _ ) { /* cross-frame focus may be blocked */ }
+      try { demoFrame.contentWindow.focus(); } catch { /* cross-frame focus may be blocked */ }
     } );
     demoFrameWrap.addEventListener( 'mouseleave', () => {
       demoFrame.style.pointerEvents = 'none';
@@ -51,7 +51,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
     // styles.css defines the same 10 [data-theme] variants the app uses.
     demoFrame.addEventListener( 'load', () => {
       let innerDoc;
-      try { innerDoc = demoFrame.contentDocument; } catch ( _ ) { return; }
+      try { innerDoc = demoFrame.contentDocument; } catch { return; }
       if ( !innerDoc || !innerDoc.documentElement ) return;
       const mirror = () => {
         const theme = innerDoc.documentElement.getAttribute( 'data-theme' );


### PR DESCRIPTION
## Summary

This Pull Request fixes the linter quality check failures on `npm run report` by ignoring the production-compiled live-demo assets under `page/demo/` within the ESLint config. It also includes a minor cleanup in the landing page script to remove unused catch parameter bindings.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor (no behavior change)
- [ ] Breaking change
- [ ] Documentation only
- [ ] Build, CI, or tooling

